### PR TITLE
Updates required in pom.xmls for first release

### DIFF
--- a/gemini-resin-archetype/pom.xml
+++ b/gemini-resin-archetype/pom.xml
@@ -17,7 +17,7 @@
   <parent>
     <groupId>com.techempower</groupId>
     <artifactId>gemini-parent</artifactId>
-    <version>2.21.0-SNAPSHOT</version>
+    <version>2.22.0-SNAPSHOT</version>
   </parent>
   
   <artifactId>gemini-resin-archetype</artifactId>

--- a/gemini-resin/pom.xml
+++ b/gemini-resin/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <artifactId>gemini-parent</artifactId>
     <groupId>com.techempower</groupId>
-    <version>2.21.0-SNAPSHOT</version>
+    <version>2.22.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>gemini-resin</artifactId>

--- a/gemini/pom.xml
+++ b/gemini/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <artifactId>gemini-parent</artifactId>
     <groupId>com.techempower</groupId>
-    <version>2.21.0-SNAPSHOT</version>
+    <version>2.22.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>gemini</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -15,9 +15,28 @@
     </license>
   </licenses>
 
+  <name>gemini-parent</name>
+  <description>
+    The parent project to Gemini and related sub-projects.
+  </description>
+  <url>https://github.com/TechEmpower/gemini</url>
   <groupId>com.techempower</groupId>
   <artifactId>gemini-parent</artifactId>
-  <version>2.21.0-SNAPSHOT</version>
+  <version>2.22.0-SNAPSHOT</version>
+  <developers>
+    <developer>
+      <id>msmith</id>
+      <name>Mike Smith</name>
+      <email>msmith@techempower.com</email>
+      <organization>TechEmpower</organization>
+      <organizationUrl>https://www.techempower.com</organizationUrl>
+      <roles>
+        <role>Directory of Open Source Initiatives</role>
+        <role>Senior Systems Architect</role>
+      </roles>
+      <timezone>America/Los_Angeles</timezone>
+    </developer>
+  </developers>
 
   <modules>
     <module>gemini</module>
@@ -57,50 +76,13 @@
   </properties>
 
   <scm>
-    <connection>scm:git:http://gitlab.techempower.com/techempower/gemini-public.git</connection>
-    <developerConnection>scm:git:git@gitlab.techempower.com:techempower/gemini-public.git</developerConnection>
+    <url>https://github.com/TechEmpower/gemini.git</url>
+    <connection>scm:git:https://github.com/TechEmpower/gemini.git</connection>
+    <developerConnection>scm:git:git@github.com:TechEmpower/gemini.git</developerConnection>
   </scm>
 
 
   <repositories>
-    <repository>
-      <id>techempower-thirdparty</id>
-      <name>Repository hosting third party libraries used by TechEmpower</name>
-      <url>https://maven.techempower.com/thirdparty</url>
-      <releases>
-        <enabled>true</enabled>
-        <updatePolicy>always</updatePolicy>
-      </releases>
-      <snapshots>
-        <enabled>false</enabled>
-        <updatePolicy>always</updatePolicy>
-      </snapshots>
-    </repository>
-    <repository>
-      <id>techempower-releases</id>
-      <name>Repository hosting releases of TechEmpower libraries</name>
-      <url>https://maven.techempower.com:8081/nexus/content/repositories/releases</url>
-      <releases>
-        <enabled>true</enabled>
-        <updatePolicy>always</updatePolicy>
-      </releases>
-      <snapshots>
-        <enabled>false</enabled>
-        <updatePolicy>always</updatePolicy>
-      </snapshots>
-    </repository>
-    <repository>
-      <id>techempower-snapshots</id>
-      <name>Repository hosting snapshots of TechEmpower libraries</name>
-      <url>https://maven.techempower.com:8081/nexus/content/repositories/snapshots</url>
-      <releases>
-        <enabled>false</enabled>
-      </releases>
-      <snapshots>
-        <enabled>true</enabled>
-        <updatePolicy>always</updatePolicy>
-      </snapshots>
-    </repository>
     <repository>
       <id>caucho</id>
       <name>Caucho's public Maven repository, which hosts Resin</name>
@@ -117,16 +99,16 @@
   </repositories>
 
   <distributionManagement>
-    <repository>
-      <id>techempower-releases</id>
-      <name>Repository hosting releases of TechEmpower libraries</name>
-      <url>https://maven.techempower.com:8081/nexus/content/repositories/releases</url>
-    </repository>
     <snapshotRepository>
-      <id>techempower-snapshots</id>
+      <id>ossrh</id>
       <name>Repository hosting snapshots of TechEmpower libraries</name>
-      <url>https://maven.techempower.com:8081/nexus/content/repositories/snapshots</url>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
     </snapshotRepository>
+    <repository>
+      <id>ossrh</id>
+      <name>Repository hosting releases of TechEmpower libraries</name>
+      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+    </repository>
   </distributionManagement>
 
   <dependencyManagement>
@@ -349,6 +331,20 @@
             </execution>
           </executions>
         </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-gpg-plugin</artifactId>
+          <version>1.5</version>
+          <executions>
+            <execution>
+              <id>sign-artifacts</id>
+              <phase>verify</phase>
+              <goals>
+                <goal>sign</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
       </plugins>
     </pluginManagement>
     <plugins>
@@ -367,6 +363,10 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-gpg-plugin</artifactId>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
We now have version [`2.21.0-SNAPSHOT`](https://oss.sonatype.org/content/repositories/snapshots/com/techempower/) and [`2.21.0`](https://oss.sonatype.org/content/repositories/releases/com/techempower/) published, and it required these changes to do.