### PR TITLE
Correct cache distribution message type

### DIFF
--- a/gemini/src/main/java/com/techempower/gemini/cluster/jms/CacheMessageManager.java
+++ b/gemini/src/main/java/com/techempower/gemini/cluster/jms/CacheMessageManager.java
@@ -247,7 +247,7 @@ public class CacheMessageManager
     log.log("Sending 'remove from cache': " + type.getSimpleName() + "/" + identifier);
 
     final CacheMessage message = new CacheMessage();
-    message.setAction(CacheMessage.ACTION_GROUP_RESET);
+    message.setAction(CacheMessage.ACTION_OBJECT_REMOVE);
     message.setGroupId(group.getGroupNumber());
     message.setObjectId(identifier);
     send(message);


### PR DESCRIPTION
A typo caused removing an object to distribute a "reset this entire
entity cache" message, resulting in every instance repopulating its cache
from the database. While this did indeed result in the object no longer
being in the cache, the performance cost was a bit excessive.