### PR TITLE
Fixes JWT not working with test users out of box

### DIFF
--- a/gemini-resin-archetype/src/main/resources/archetype-resources/src/test/resources/db/migration/V2018.08.20.07.07.00__Insert_Testing_Accounts.sql
+++ b/gemini-resin-archetype/src/main/resources/archetype-resources/src/test/resources/db/migration/V2018.08.20.07.07.00__Insert_Testing_Accounts.sql
@@ -1,9 +1,9 @@
 /* Inserts some testing user accounts.  Delete these in a production environment. */
 
 /* Username / Password: user / test */
-INSERT INTO "user" (userusername, userfirstname, userlastname, useremail, userpassword, enabled) VALUES ('user', 'first', 'last', 'none-user@techempower.com', '$2a$12$OepZj8bxnM9vrVHr1x7/k.6gE8QJZ8OKLTs7PPFhUopilS2RmQjq.', true);
+INSERT INTO "user" (userusername, userfirstname, userlastname, useremail, userpassword, enabled, userlastpasswordchange) VALUES ('user', 'first', 'last', 'none-user@techempower.com', '$2a$12$OepZj8bxnM9vrVHr1x7/k.6gE8QJZ8OKLTs7PPFhUopilS2RmQjq.', true, now());
 /* Username / Password: admin / test */
-INSERT INTO "user" (userusername, userfirstname, userlastname, useremail, userpassword, enabled) VALUES ('admin', 'first', 'last', 'none-admin@techempower.com', '$2a$12$OepZj8bxnM9vrVHr1x7/k.6gE8QJZ8OKLTs7PPFhUopilS2RmQjq.', true);
+INSERT INTO "user" (userusername, userfirstname, userlastname, useremail, userpassword, enabled, userlastpasswordchange) VALUES ('admin', 'first', 'last', 'none-admin@techempower.com', '$2a$12$OepZj8bxnM9vrVHr1x7/k.6gE8QJZ8OKLTs7PPFhUopilS2RmQjq.', true, now());
 
 INSERT INTO usertogroup (userid, groupid) VALUES (1, 1);
 INSERT INTO usertogroup (userid, groupid) VALUES (2, 1);


### PR DESCRIPTION
Without a value for `userlastpasswordchange`, the token reader would throw an exception and never return a valid token (even if the user's token was indeed valid).

This fixes the issue for the test users, and implementations with registration should remember to provide a non-null value to this field.