### PR TITLE
Support conventional usage of java.sql.Connection

### DIFF
--- a/gemini-jdbc/src/main/java/com/techempower/data/jdbc/ConnectionWrapper.java
+++ b/gemini-jdbc/src/main/java/com/techempower/data/jdbc/ConnectionWrapper.java
@@ -1,0 +1,374 @@
+package com.techempower.data.jdbc;
+
+import java.sql.*;
+import java.util.*;
+import java.util.concurrent.*;
+
+/**
+ * Mostly a pass-through to the real connection, except for close() and
+ * isClosed() which ask the JdbcConnectionProfile instead. This allows the
+ * existing pooling logic in JdbcConnectionProfile to be used, and prevents a
+ * pooled connection from being closed accidentally.
+ */
+public class ConnectionWrapper
+    implements Connection
+{
+  private JdbcConnectionProfile profile;
+  private Connection connection;
+
+  public ConnectionWrapper(JdbcConnectionProfile profile, Connection connection)
+  {
+    this.profile = profile;
+    this.connection = connection;
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public <T> T unwrap(Class<T> iface) throws SQLException
+  {
+    return (T)connection;
+  }
+
+  @Override
+  public boolean isWrapperFor(Class<?> iface) throws SQLException
+  {
+    return iface.isInstance(connection);
+  }
+
+  @Override
+  public Statement createStatement() throws SQLException
+  {
+    return connection.createStatement();
+  }
+
+  @Override
+  public PreparedStatement prepareStatement(String sql) throws SQLException
+  {
+    return connection.prepareStatement(sql);
+  }
+
+  @Override
+  public CallableStatement prepareCall(String sql) throws SQLException
+  {
+    return connection.prepareCall(sql);
+  }
+
+  @Override
+  public String nativeSQL(String sql) throws SQLException
+  {
+    return connection.nativeSQL(sql);
+  }
+
+  @Override
+  public void setAutoCommit(boolean autoCommit) throws SQLException
+  {
+    connection.setAutoCommit(autoCommit);
+  }
+
+  @Override
+  public boolean getAutoCommit() throws SQLException
+  {
+    return connection.getAutoCommit();
+  }
+
+  @Override
+  public void commit() throws SQLException
+  {
+    connection.commit();
+  }
+
+  @Override
+  public void rollback() throws SQLException
+  {
+    connection.rollback();
+  }
+
+  @Override
+  public void close() throws SQLException
+  {
+    this.profile.close();
+  }
+
+  public void closeUnderlyingConnection() throws SQLException
+  {
+    connection.close();
+  }
+
+  @Override
+  public boolean isClosed() throws SQLException
+  {
+    return this.profile.isClosed();
+  }
+
+  public boolean isClosedUnderlyingConnection() throws SQLException
+  {
+    return connection.isClosed();
+  }
+
+  @Override
+  public DatabaseMetaData getMetaData() throws SQLException
+  {
+    return connection.getMetaData();
+  }
+
+  @Override
+  public void setReadOnly(boolean readOnly) throws SQLException
+  {
+    connection.setReadOnly(readOnly);
+  }
+
+  @Override
+  public boolean isReadOnly() throws SQLException
+  {
+    return connection.isReadOnly();
+  }
+
+  @Override
+  public void setCatalog(String catalog) throws SQLException
+  {
+    connection.setCatalog(catalog);
+  }
+
+  @Override
+  public String getCatalog() throws SQLException
+  {
+    return connection.getCatalog();
+  }
+
+  @Override
+  public void setTransactionIsolation(int level) throws SQLException
+  {
+    connection.setTransactionIsolation(level);
+  }
+
+  @Override
+  public int getTransactionIsolation() throws SQLException
+  {
+    return connection.getTransactionIsolation();
+  }
+
+  @Override
+  public SQLWarning getWarnings() throws SQLException
+  {
+    return connection.getWarnings();
+  }
+
+  @Override
+  public void clearWarnings() throws SQLException
+  {
+    connection.clearWarnings();
+  }
+
+  @Override
+  public Statement createStatement(int resultSetType,
+      int resultSetConcurrency) throws SQLException
+  {
+    return connection.createStatement(resultSetType, resultSetConcurrency);
+  }
+
+  @Override
+  public PreparedStatement prepareStatement(String sql, int resultSetType,
+      int resultSetConcurrency) throws SQLException
+  {
+    return connection.prepareStatement(sql, resultSetType, resultSetConcurrency);
+  }
+
+  @Override
+  public CallableStatement prepareCall(String sql, int resultSetType,
+      int resultSetConcurrency) throws SQLException
+  {
+    return connection.prepareCall(sql, resultSetType, resultSetConcurrency);
+  }
+
+  @Override
+  public Map<String, Class<?>> getTypeMap() throws SQLException
+  {
+    return connection.getTypeMap();
+  }
+
+  @Override
+  public void setTypeMap(Map<String, Class<?>> map) throws SQLException
+  {
+    connection.setTypeMap(map);
+  }
+
+  @Override
+  public void setHoldability(int holdability) throws SQLException
+  {
+    connection.setHoldability(holdability);
+  }
+
+  @Override
+  public int getHoldability() throws SQLException
+  {
+    return connection.getHoldability();
+  }
+
+  @Override
+  public Savepoint setSavepoint() throws SQLException
+  {
+    return connection.setSavepoint();
+  }
+
+  @Override
+  public Savepoint setSavepoint(String name) throws SQLException
+  {
+    return connection.setSavepoint(name);
+  }
+
+  @Override
+  public void rollback(Savepoint savepoint) throws SQLException
+  {
+    connection.rollback(savepoint);
+  }
+
+  @Override
+  public void releaseSavepoint(Savepoint savepoint) throws SQLException
+  {
+    connection.releaseSavepoint(savepoint);
+  }
+
+  @Override
+  public Statement createStatement(int resultSetType,
+      int resultSetConcurrency, int resultSetHoldability) throws SQLException
+  {
+    return connection.createStatement(resultSetType, resultSetConcurrency, resultSetHoldability);
+  }
+
+  @Override
+  public PreparedStatement prepareStatement(String sql, int resultSetType,
+      int resultSetConcurrency, int resultSetHoldability) throws SQLException
+  {
+    return connection.prepareStatement(sql, resultSetType, resultSetConcurrency, resultSetHoldability);
+  }
+
+  @Override
+  public CallableStatement prepareCall(String sql, int resultSetType,
+      int resultSetConcurrency, int resultSetHoldability) throws SQLException
+  {
+    return connection.prepareCall(sql, resultSetType, resultSetConcurrency, resultSetHoldability);
+  }
+
+  @Override
+  public PreparedStatement prepareStatement(String sql, int autoGeneratedKeys)
+      throws SQLException
+  {
+    return connection.prepareStatement(sql, autoGeneratedKeys);
+  }
+
+  @Override
+  public PreparedStatement prepareStatement(String sql, int[] columnIndexes)
+      throws SQLException
+  {
+    return connection.prepareStatement(sql, columnIndexes);
+  }
+
+  @Override
+  public PreparedStatement prepareStatement(String sql, String[] columnNames)
+      throws SQLException
+  {
+    return connection.prepareStatement(sql, columnNames);
+  }
+
+  @Override
+  public Clob createClob() throws SQLException
+  {
+    return connection.createClob();
+  }
+
+  @Override
+  public Blob createBlob() throws SQLException
+  {
+    return connection.createBlob();
+  }
+
+  @Override
+  public NClob createNClob() throws SQLException
+  {
+    return connection.createNClob();
+  }
+
+  @Override
+  public SQLXML createSQLXML() throws SQLException
+  {
+    return connection.createSQLXML();
+  }
+
+  @Override
+  public boolean isValid(int timeout) throws SQLException
+  {
+    return connection.isValid(timeout);
+  }
+
+  @Override
+  public void setClientInfo(String name, String value)
+      throws SQLClientInfoException
+  {
+    connection.setClientInfo(name, value);
+  }
+
+  @Override
+  public void setClientInfo(Properties properties)
+      throws SQLClientInfoException
+  {
+    connection.setClientInfo(properties);
+  }
+
+  @Override
+  public String getClientInfo(String name) throws SQLException
+  {
+    return connection.getClientInfo(name);
+  }
+
+  @Override
+  public Properties getClientInfo() throws SQLException
+  {
+    return connection.getClientInfo();
+  }
+
+  @Override
+  public Array createArrayOf(String typeName, Object[] elements)
+      throws SQLException
+  {
+    return connection.createArrayOf(typeName, elements);
+  }
+
+  @Override
+  public Struct createStruct(String typeName, Object[] attributes)
+      throws SQLException
+  {
+    return connection.createStruct(typeName, attributes);
+  }
+
+  @Override
+  public void setSchema(String schema) throws SQLException
+  {
+    connection.setSchema(schema);
+  }
+
+  @Override
+  public String getSchema() throws SQLException
+  {
+    return connection.getSchema();
+  }
+
+  @Override
+  public void abort(Executor executor) throws SQLException
+  {
+    connection.abort(executor);
+  }
+
+  @Override
+  public void setNetworkTimeout(Executor executor, int milliseconds)
+      throws SQLException
+  {
+    connection.setNetworkTimeout(executor, milliseconds);
+  }
+
+  @Override
+  public int getNetworkTimeout() throws SQLException
+  {
+    return connection.getNetworkTimeout();
+  }
+
+}

--- a/gemini-jdbc/src/main/java/com/techempower/data/jdbc/JdbcConnector.java
+++ b/gemini-jdbc/src/main/java/com/techempower/data/jdbc/JdbcConnector.java
@@ -848,7 +848,7 @@ public class JdbcConnector
     // Notify the Profile that we're done using it.
     if (this.connectionProfile != null)
     {
-      this.connectionProfile.release();
+      this.connectionProfile.close();
       this.connectionProfile = null;
     }
 

--- a/gemini/src/main/java/com/techempower/gemini/GeminiHelper.java
+++ b/gemini/src/main/java/com/techempower/gemini/GeminiHelper.java
@@ -141,7 +141,9 @@ public final class GeminiHelper
       Context context, List<? extends TabularColumn> fieldAttribs, String query,
       String exportFilename, ComponentLog log) throws SQLException
   {
-    try (PreparedStatement statement = application.getConnectorFactory().getConnectionMonitor().getConnection().prepareStatement(
+    try (
+        Connection c = application.getConnectorFactory().getConnectionMonitor().getConnection();
+        PreparedStatement statement = c.prepareStatement(
         query))
     {
       ResultSet resultSet = statement.executeQuery();

--- a/gemini/src/main/java/com/techempower/gemini/lifecycle/InitDatabaseConnectionTest.java
+++ b/gemini/src/main/java/com/techempower/gemini/lifecycle/InitDatabaseConnectionTest.java
@@ -71,7 +71,8 @@ public class InitDatabaseConnectionTest
       log.log("Testing database connectivity.");
       log.log("Running test query: " + testQuery);
       try (
-          PreparedStatement statement = cf.getConnectionMonitor().getConnection().prepareStatement(testQuery)
+          Connection c = cf.getConnectionMonitor().getConnection();
+          PreparedStatement statement = c.prepareStatement(testQuery)
           )
       {
         ResultSet resultSet = statement.executeQuery();

--- a/gemini/src/main/java/com/techempower/helper/CollectionHelper.java
+++ b/gemini/src/main/java/com/techempower/helper/CollectionHelper.java
@@ -786,6 +786,22 @@ public final class CollectionHelper
   }
 
   /**
+   * Converts a Collection of String objects to a simple long[] by parsing each
+   * String using NumberHelper.parseLong.
+   */
+  public static long[] toLongArrayFromStrings(Collection<String> collectionOfStrings)
+  {
+    long[] toReturn = new long[collectionOfStrings.size()];
+    int position = 0;
+    for (String s : collectionOfStrings)
+    {
+      toReturn[position++] = NumberHelper.parseLong(s);
+    }
+
+    return toReturn;
+  }
+
+  /**
    * Converts a Collection of Strings to a String array.
    */
   public static String[] toStringArray(Collection<String> collectionOfStrings)


### PR DESCRIPTION
Whether the ConnectionMonitor or the ConnectionWrapper instance is put in client code's try-with-finally block, the gemini-jdbc connection pooling still functions correctly now.

In the future, we should probably consider deprecating ConnectionMonitor to reduce confusion.