### PR TITLE
Fixes the javadoc stage of building on jdk11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -324,6 +324,10 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-javadoc-plugin</artifactId>
           <version>${maven-javadoc-plugin.version}</version>
+          <configuration>
+            <source>8</source>
+            <additionalOptions>-Xdoclint:none</additionalOptions>
+          </configuration>
           <executions>
             <execution>
               <id>attach-javadocs</id>


### PR DESCRIPTION
This is a known issue with all JDK11s, and it will presumably be fixed someday, but for now this will do.