### PR TITLE
Log Standardization Options

### DIFF
--- a/gemini-resin-archetype/src/main/resources/archetype-resources/src/main/webapp/WEB-INF/configuration/Base.conf
+++ b/gemini-resin-archetype/src/main/resources/archetype-resources/src/main/webapp/WEB-INF/configuration/Base.conf
@@ -185,6 +185,26 @@ Log.File.LogDirectory = ${ApplicationRoot}WEB-INF/Logs/Application-Logs/
 Log.File.LogDebugThreshold = 20
 Log.Console.LogDebugThreshold = 20
 
+# Log.File.SeverityPrefixEnabled -and-
+# Log.Console.SeverityPrefixEnabled
+#   Specify whether or not a severity prefix should be prefixed to each
+#   logged message. These severity prefixes include [INFO], [WARN], and
+#   [ERROR]. The severity prefixes are right-padded with spaces as
+#   necessary to keep everything the same length.
+
+Log.File.SeverityPrefixEnabled = off
+Log.Console.SeverityPrefixEnabled = off
+
+# Log.File.StripControlCharacters
+#   Specifies whether or not ISO control characters should be stripped
+#   from messages before being written to the log file. By stripping
+#   these characters, every line of the log file is a distinct message,
+#   and each line is guaranteed to be well-formatted. If stripping is
+#   disabled, things like stack traces will be allowed to take up
+#   multiple indented lines. Enabled if not specified.
+
+Log.File.StripControlCharacters = on
+
 
 # -----------------------------------------------------------------------
 # IP/DNS/URL SETTINGS

--- a/gemini/src/main/java/com/techempower/log/AbstractLogListener.java
+++ b/gemini/src/main/java/com/techempower/log/AbstractLogListener.java
@@ -404,15 +404,15 @@ public abstract class AbstractLogListener
   {
     if (logLevel < ALERT)
     {
-      return "[INFO]   ";
+      return "[INFO]  ";
     }
     else if (logLevel < CRITICAL)
     {
-      return "[WARN]   ";
+      return "[WARN]  ";
     }
     else
     {
-      return "[ERROR]  ";
+      return "[ERROR] ";
     }
   }
   

--- a/gemini/src/main/java/com/techempower/log/AbstractLogListener.java
+++ b/gemini/src/main/java/com/techempower/log/AbstractLogListener.java
@@ -48,11 +48,12 @@ public abstract class AbstractLogListener
   //
   
   private final TechEmpowerApplication application;
-  private int                    debugThreshold  = MINIMUM;
-  private long                   endOfDay        = DateHelper.getEndOfDay().getTimeInMillis();
-  private long                   nextSecond      = 0L;
-  private String                 fullTimestamp   = null;
-  private String                 briefTimestamp  = null;
+  private int                    debugThreshold        = MINIMUM;
+  private long                   endOfDay              = DateHelper.getEndOfDay().getTimeInMillis();
+  private long                   nextSecond            = 0L;
+  private String                 fullTimestamp         = null;
+  private String                 briefTimestamp        = null;
+  private boolean                severityPrefixEnabled = false;
 
   /**
    * Only create the Calendar instance once, and then call setTimeInMillis()
@@ -363,6 +364,29 @@ public abstract class AbstractLogListener
   }
 
   /**
+   * If true, a severity prefix will be placed at the very front of each logged
+   * message.
+   */
+  @Override
+  public boolean isSeverityPrefixEnabled()
+  {
+    return severityPrefixEnabled;
+  }
+
+  /**
+   * Sets whether or not a severity prefix will be included. The prefix will be
+   * placed at the very front of each logged message.
+   *
+   * @param severityPrefixEnabled whether or not the severity prefix will be
+   *                              included
+   */
+  @Override
+  public void setSeverityPrefixEnabled(boolean severityPrefixEnabled)
+  {
+    this.severityPrefixEnabled = severityPrefixEnabled;
+  }
+
+  /**
    * Determines if we have entered a new day (indicating it's time for a new
    * log file, assuming we're writing log files.
    */
@@ -374,6 +398,22 @@ public abstract class AbstractLogListener
       return true;
     }
     return false;
+  }
+
+  protected String getLogLevelPrefix(int logLevel)
+  {
+    if (logLevel < ALERT)
+    {
+      return "[INFO]   ";
+    }
+    else if (logLevel < CRITICAL)
+    {
+      return "[WARN]   ";
+    }
+    else
+    {
+      return "[ERROR]  ";
+    }
   }
   
 }

--- a/gemini/src/main/java/com/techempower/log/BasicLog.java
+++ b/gemini/src/main/java/com/techempower/log/BasicLog.java
@@ -91,8 +91,8 @@ public class BasicLog
     // this default listener will be removed before adding any new ones.
     this.consoleLog = new ConsoleLogListener(
         getApplication(),
-        0 // Debug level
-      );
+        0, // Debug level
+      false);
     
     addListener(this.consoleLog);
     
@@ -157,8 +157,14 @@ public class BasicLog
         }
       }
 
+      boolean includeSeverityPrefix = props.getBoolean(
+          "Log.File.SeverityPrefixEnabled", false);
+      boolean stripControlCharacters = props.getBoolean(
+          "Log.File.StripControlCharacters", true);
+
       this.fileLog = new FileLogListener(getApplication(), logDirectory,
-          logFilenamePrefix, logFilenameSuffix, fileDebugThreshold);
+          logFilenamePrefix, logFilenameSuffix, fileDebugThreshold,
+          includeSeverityPrefix, stripControlCharacters);
 
       listeners.add(this.fileLog);
     }
@@ -168,9 +174,10 @@ public class BasicLog
     {
       int consoleDebugThreshold = props.getInt(
           "Log.Console.LogDebugThreshold", getDebugThreshold());
+      boolean severityPrefixEnabled = props.getBoolean("Log.Console.SeverityPrefixEnabled", false);
 
       this.consoleLog = new ConsoleLogListener(getApplication(),
-          consoleDebugThreshold);
+          consoleDebugThreshold, severityPrefixEnabled);
 
       listeners.add(this.consoleLog);
     }

--- a/gemini/src/main/java/com/techempower/log/ConsoleLogListener.java
+++ b/gemini/src/main/java/com/techempower/log/ConsoleLogListener.java
@@ -51,12 +51,15 @@ public class ConsoleLogListener
    *
    * @param application a reference to the application using the Log.
    * @param threshold The minimum log level that this listener will process.
+   * @param severityPrefixEnabled whether or not the severity prefix will be
+   *                              included
    */
   public ConsoleLogListener(TechEmpowerApplication application, 
-                            int threshold)
+                            int threshold, boolean severityPrefixEnabled)
   {
     super(application);
     setDebugThreshold(threshold);
+    setSeverityPrefixEnabled(severityPrefixEnabled);
   }
 
   /**
@@ -120,6 +123,10 @@ public class ConsoleLogListener
     computeTimestamps();
 
     StringBuilder buffer = new StringBuilder(120);
+    if (isSeverityPrefixEnabled())
+    {
+      buffer.append(getLogLevelPrefix(debugLevel));
+    }
     buffer.append(getApplication().getVersion().getProductCode());
     buffer.append(' ');
     buffer.append(getBriefTimestamp());

--- a/gemini/src/main/java/com/techempower/log/LogListener.java
+++ b/gemini/src/main/java/com/techempower/log/LogListener.java
@@ -206,4 +206,19 @@ public interface LogListener
    */
   int getDebugThreshold();
 
+  /**
+   * If true, a severity prefix will be placed at the very front of each logged
+   * message.
+   */
+  boolean isSeverityPrefixEnabled();
+
+  /**
+   * Sets whether or not a severity prefix will be included. The prefix will be
+   * placed at the very front of each logged message.
+   *
+   * @param severityPrefixEnabled whether or not the severity prefix will be
+   *                              included
+   */
+  void setSeverityPrefixEnabled(boolean severityPrefixEnabled);
+
 }  // end LogListener.


### PR DESCRIPTION
## Added Features

#### File/Console Log - Severity Prefixes

Severity indicators (eg, INFO, WARN, ERROR) can optionally be prefixed to each line. Aside from just standard viewing, this is beneficial to log viewers like [Ideolog](https://plugins.jetbrains.com/plugin/9746-ideolog) (such poor review scores...) which can use them for filtering, etc (provided you configure it to recognize the log format).

#### File Log - Optionally Disable Control Character Stripping

Previously the file log would strip ISO control characters from logged messages for the sake of keeping a uniform structure to log files. And although there's value in that, it also makes it quite difficult to actually read a stack trace that was logged, which is often the very thing you're interested in reading. Also, in the case of Ideolog, your IDE may be able to provide links to the classes based on those stack traces so long as each element in the stack is given a separate line.

To demonstrate, here's a comparison of the formatted and unformatted stack traces in IntelliJ with Ideolog enabled (also I have all sources downloaded, including Resin). I couldn't fit the unformatted stack trace in a single 2k screenshot, so I took eight of them (at max zoom). 

https://imgur.com/a/vGYftim

I had to try a number of image upload websites before I could find one that would let me upload the full 14k x 20 image that I stitched together, but here it is:

https://cdn3.imggmi.com/uploads/2019/8/14/21d9534ae0e19b9d0cee5b93f78346ea-full.png

#### Notes
- Exceptions are being logged as `LogLevel.NORMAL`, which seems wrong to me. I set up the log level severity mapping to where anything less than `LogLevel.ALERT` is "INFO", anything less than `LogLevel.CRITICAL` is "WARN" (so basically only `LogLevel.ALERT`), and everything else (`LogLevel.CRITICAL`, `LogLevel.MAXIMUM`) is an "ERROR". Personally I think all exceptions should be ERRORs unless otherwise specified, but WARNING could be a good middleground. I definitely don't think they should be INFO, which is where they currently land.