### PR TITLE
Extended request body support

### DIFF
--- a/gemini-resin/src/main/java/com/techempower/gemini/HttpRequest.java
+++ b/gemini-resin/src/main/java/com/techempower/gemini/HttpRequest.java
@@ -236,6 +236,12 @@ public class HttpRequest
     this.request.setCharacterEncoding(encoding);
   }
 
+  @Override
+  public String getRequestCharacterEncoding()
+  {
+    return this.request.getCharacterEncoding();
+  }
+
   /**
    * Returns all the Header names for this request
    */
@@ -711,6 +717,7 @@ public class HttpRequest
    * pass-through to response.getOutputStream().
    * @throws IOException 
    */
+  @Override
   public InputStream getInputStream() 
     throws IOException
   {

--- a/gemini/src/main/java/com/techempower/gemini/GeminiApplication.java
+++ b/gemini/src/main/java/com/techempower/gemini/GeminiApplication.java
@@ -558,7 +558,7 @@ public abstract class GeminiApplication
    */
   protected JavaScriptWriter constructJavaScriptWriter()
   {
-    return LegacyJavaScriptWriter.standard();
+    return new JacksonJavaScriptWriter();
   }
 
   /**

--- a/gemini/src/main/java/com/techempower/gemini/GeminiApplication.java
+++ b/gemini/src/main/java/com/techempower/gemini/GeminiApplication.java
@@ -146,6 +146,7 @@ public abstract class GeminiApplication
   private final FeatureManager             featureManager;
   private final Notifier                   notifier;
   private final JavaScriptWriter           standardJsw;
+  private final JavaScriptReader           standardJsr;
   private final MustacheManager            mustacheManager;
   private final Lifecycle                  lifecycle;
   private       RequestListener[]          listeners       = new RequestListener[0];
@@ -197,6 +198,7 @@ public abstract class GeminiApplication
       this.lifecycle            = constructLifecycle();
       this.configurator         = constructConfigurator();
       this.standardJsw          = constructJavaScriptWriter();
+      this.standardJsr          = constructJavaScriptReader();
       this.featureManager       = constructFeatureManager();
       this.connectorFactory     = constructConnectorFactory();
       this.databaseMigrator     = constructDatabaseMigrator();
@@ -558,7 +560,16 @@ public abstract class GeminiApplication
   {
     return LegacyJavaScriptWriter.standard();
   }
-  
+
+  /**
+   * Construct and configure a JavaScriptReader suitable for application-wide
+   * general usage.
+   */
+  protected JavaScriptReader constructJavaScriptReader()
+  {
+    return new JacksonJavaScriptReader();
+  }
+
   /**
    * Construct a MustacheManager for interfacing with the Java Mustache 
    * template library. 
@@ -728,7 +739,18 @@ public abstract class GeminiApplication
   {
     return standardJsw;
   }
-  
+
+  /**
+   * Gets the application's standard JavaScriptReader.  Note that an
+   * application may use additional JavaScriptReaders for other contexts.
+   * The application's main JavaScriptReader will be used as the default,
+   * for example when parsing a JSON request body.
+   */
+  public JavaScriptReader getJavaScriptReader()
+  {
+    return standardJsr;
+  }
+
   /**
    * Gets the Configurator.
    */

--- a/gemini/src/main/java/com/techempower/gemini/Request.java
+++ b/gemini/src/main/java/com/techempower/gemini/Request.java
@@ -86,7 +86,12 @@ public interface Request
    * application.
    */
   void setCharacterEncoding(String encoding) throws UnsupportedEncodingException;
-  
+
+  /**
+   * Returns the character encoding associated with the request.
+   */
+  String getRequestCharacterEncoding();
+
   /**
    * Returns all the Header names for this request
    */
@@ -207,6 +212,11 @@ public interface Request
    * Gets the request's method as a String.
    */
   HttpMethod getRequestMethod();
+
+  /**
+   * Gets the input stream for the request body.
+   */
+  InputStream getInputStream() throws IOException;
   
   /**
    * Redirect the browser to a new location using HTTP response code 302

--- a/gemini/src/main/java/com/techempower/gemini/path/BasicPathHandler.java
+++ b/gemini/src/main/java/com/techempower/gemini/path/BasicPathHandler.java
@@ -759,12 +759,17 @@ public abstract class BasicPathHandler<C extends Context>
    */
   protected static abstract class BasicPathHandlerMethod
   {
+    private static final Set<HttpMethod> SUPPORTED_BODY_METHODS = EnumSet.of(
+            HttpMethod.POST, HttpMethod.PUT, HttpMethod.PATCH);
+
     public final Method method;
+    public final HttpMethod httpMethod;
     public final RequestBodyParameter bodyParameter;
 
-    BasicPathHandlerMethod(Method method)
+    BasicPathHandlerMethod(Method method, HttpMethod httpMethod)
     {
       this.method = method;
+      this.httpMethod = httpMethod;
 
       Body body = method.getAnnotation(Body.class);
       // We allow users to create their own annotations (that must be annotated
@@ -782,6 +787,14 @@ public abstract class BasicPathHandler<C extends Context>
       }
       if (body != null)
       {
+        if (!SUPPORTED_BODY_METHODS.contains(httpMethod))
+        {
+          throw new IllegalArgumentException("The " + httpMethod.name()
+                  + " HTTP method does not support request bodies, but there is "
+                  + "a @Body annotation present. See " + getClass().getName() + "#"
+                  + method.getName());
+        }
+
         // A body parameter may be generic, for example Map<String, Object>,
         // so use the generic parameter type for the body parameter, which
         // will return a ParameterizedType if necessary.

--- a/gemini/src/main/java/com/techempower/gemini/path/JsonRequestBodyAdapter.java
+++ b/gemini/src/main/java/com/techempower/gemini/path/JsonRequestBodyAdapter.java
@@ -1,0 +1,49 @@
+package com.techempower.gemini.path;
+
+import java.io.IOException;
+import java.lang.reflect.Type;
+
+import com.techempower.gemini.Context;
+import com.techempower.gemini.GeminiConstants;
+import com.techempower.gemini.Request;
+import com.techempower.helper.StringHelper;
+import com.techempower.js.JavaScriptError;
+
+/**
+ * A request body adapter that uses the application's default
+ * JavaScriptReader to de-serialize the request body. This
+ * adapter expects that the request content type is application/json
+ * and throws an exception if that is not the case.
+ *
+ * @see com.techempower.gemini.path.annotation.ConsumesJson
+ */
+public class JsonRequestBodyAdapter implements RequestBodyAdapter<Context>
+{
+  @Override
+  public Object read(Context context, Type type) throws RequestBodyException
+  {
+    final Request request = context.getRequest();
+
+    // Ensure that the requests had the right content type.
+    if (!StringHelper.equalsIgnoreCase(
+            request.getRequestContentType(), GeminiConstants.CONTENT_TYPE_JSON))
+    {
+      throw new RequestBodyException(400, "Invalid content type: "
+          + request.getRequestContentType());
+    }
+
+    try
+    {
+      // Attempt de-serialization.
+      return context.getApplication().getJavaScriptReader().read(request.getInputStream(), type);
+    }
+    catch (IOException e)
+    {
+      throw new RequestBodyException(500, "Internal server error", e);
+    }
+    catch(JavaScriptError e)
+    {
+      throw new RequestBodyException(400, "Error parsing request body as JSON.", e);
+    }
+  }
+}

--- a/gemini/src/main/java/com/techempower/gemini/path/MethodSegmentHandler.java
+++ b/gemini/src/main/java/com/techempower/gemini/path/MethodSegmentHandler.java
@@ -559,17 +559,15 @@ public class MethodSegmentHandler<C extends Context>
   protected static class PathSegmentMethod extends BasicPathHandlerMethod
   {
     public final String name;      // For debugging purposes only.
-    public final HttpMethod httpMethod;
     public final int index;
     public final boolean contextParameter;
     
     public PathSegmentMethod(Method method, HttpMethod httpMethod,
         MethodAccess methodAccess)
     {
-      super(method);
+      super(method, httpMethod);
 
       this.name = method.getName();
-      this.httpMethod = httpMethod;
 
       final Class<?>[] parameterTypes = method.getParameterTypes();
       this.index = methodAccess.getIndex(method.getName(), parameterTypes);

--- a/gemini/src/main/java/com/techempower/gemini/path/MethodUriHandler.java
+++ b/gemini/src/main/java/com/techempower/gemini/path/MethodUriHandler.java
@@ -641,18 +641,16 @@ public class MethodUriHandler<C extends Context>
     public final Method method;
     public final String uri;
     public final UriSegment[] segments;
-    public final HttpMethod httpMethod;
     public final int index;
     
     public PathUriMethod(Method method, String uri, HttpMethod httpMethod,
         MethodAccess methodAccess)
     {
-      super(method);
+      super(method, httpMethod);
 
       this.method = method;
       this.uri = uri;
       this.segments = this.parseSegments(this.uri);
-      this.httpMethod = httpMethod;
       int variableCount = 0;
       final Class<?>[] classes = 
           new Class[method.getGenericParameterTypes().length];

--- a/gemini/src/main/java/com/techempower/gemini/path/MethodUriHandler.java
+++ b/gemini/src/main/java/com/techempower/gemini/path/MethodUriHandler.java
@@ -450,9 +450,7 @@ public class MethodUriHandler<C extends Context>
     final RequestBodyParameter bodyParameter = method.bodyParameter;
     if (bodyParameter != null && argsIndex < args.length)
     {
-      Object body = ((RequestBodyAdapter<C>) bodyParameter.adapter).read(
-              context, bodyParameter.type);
-      args[argsIndex] = body;
+      args[argsIndex] = bodyParameter.readBody(context);
     }
 
     return args;
@@ -638,18 +636,19 @@ public class MethodUriHandler<C extends Context>
   /**
    * Details of an annotated path segment method.
    */
-  protected static class PathUriMethod
+  protected static class PathUriMethod extends BasicPathHandlerMethod
   {
     public final Method method;
     public final String uri;
     public final UriSegment[] segments;
     public final HttpMethod httpMethod;
-    public final RequestBodyParameter bodyParameter;
     public final int index;
     
     public PathUriMethod(Method method, String uri, HttpMethod httpMethod,
         MethodAccess methodAccess)
     {
+      super(method);
+
       this.method = method;
       this.uri = uri;
       this.segments = this.parseSegments(this.uri);
@@ -672,40 +671,15 @@ public class MethodUriHandler<C extends Context>
       // Check for and configure the method to receive a parameter for the
       // request body. If desired, it's expected that the body parameter is
       // the last one. So it's only worth checking if variableCount indicates
-      // that there's room left in the classes array.
-      RequestBodyParameter bodyParameter = null;
-      if (variableCount < classes.length)
+      // that there's room left in the classes array. If there is a mismatch
+      // where there is another parameter and no @Body annotation, or there is
+      // a @Body annotation and no extra parameter for it, the below checks
+      // will find that and throw accordingly.
+      if (variableCount < classes.length && this.bodyParameter != null)
       {
-        Body body = method.getAnnotation(Body.class);
-        // We allow users to create their own annotations (that must be annotated
-        // with @Body), so scan the method's annotations.
-        if (body == null)
-        {
-          for (Annotation annotation : method.getAnnotations())
-          {
-            body = annotation.annotationType().getAnnotation(Body.class);
-            if (body != null)
-            {
-              break;
-            }
-          }
-        }
-        if (body != null)
-        {
-          // While path parameters can only be primitives, enums, and strings,
-          // a body parameter may be generic, for example Map<String, Object>.
-          // It's sufficient to use the class, for example Map.class, in the
-          // classes array used for determining the method's index. However,
-          // the body adapter may need more info than this, so use the generic
-          // parameter type for the body parameter, which will return a
-          // ParameterizedType instance that cannot be cast to Class<?>.
-          classes[variableCount] = method.getParameterTypes()[variableCount];
-          bodyParameter = new RequestBodyParameter(body.value(),
-                  method.getGenericParameterTypes()[variableCount]);
-          variableCount++;
-        }
+        classes[variableCount] = method.getParameterTypes()[variableCount];
+        variableCount++;
       }
-      this.bodyParameter = bodyParameter;
 
       if (variableCount == 0)
       {
@@ -823,39 +797,6 @@ public class MethodUriHandler<C extends Context>
         return "{segment: '" + segment + 
             "', isVariable: " + isVariable + 
             ", isWildcard: " + isWildcard + "}";
-      }
-    }
-
-    /**
-     * <p>Represents a parameter that is populated from the request body.
-     * This must be the last parameter to the handler method, and is
-     * created when we detect a {@link Body} annotation (or a custom
-     * annotation that has {@link Body}).</p>
-     *
-     * <p>The {@link #adapter} is an instance of the adapter class
-     * that was specified by the body annotation {@link Body#value()},
-     * created by invoking the class's empty constructor.</p>
-     *
-     * <p>The {@link #type} is that generic parameter type of the last
-     * parameter to the method.</p>
-     */
-    protected static class RequestBodyParameter
-    {
-      public final RequestBodyAdapter<?> adapter;
-      public final Type type;
-
-      private RequestBodyParameter(Class<? extends RequestBodyAdapter<?>> adapterClass, Type type)
-      {
-        try
-        {
-          this.adapter = adapterClass.getDeclaredConstructor().newInstance();
-          this.type = type;
-        }
-        catch (Exception e)
-        {
-          throw new IllegalArgumentException("Unable to construct request body adapter of type "
-              + adapterClass.getName());
-        }
       }
     }
   }

--- a/gemini/src/main/java/com/techempower/gemini/path/RequestBodyAdapter.java
+++ b/gemini/src/main/java/com/techempower/gemini/path/RequestBodyAdapter.java
@@ -1,0 +1,38 @@
+package com.techempower.gemini.path;
+
+import java.lang.reflect.Type;
+
+import com.techempower.gemini.Context;
+
+/**
+ * <p>An interface whose implementations are responsible for adapting
+ * or transforming a request's body to a format for handlers to use.</p>
+ *
+ * <p>You may implement this interface and specify that your
+ * implementation should be used for adapting requests using the
+ * {@link com.techempower.gemini.path.annotation.Body} annotation.
+ * Your implementation must have a public no-arguments constructor.
+ * It will be instantiated once and used for the life of the handler
+ * method. Instances are not shared between handler methods, meaning
+ * there is an instance for each method annotated with @Body.</p>
+ *
+ * @param <C> Your application's Context type.
+ * @see com.techempower.gemini.path.annotation.Body
+ */
+public interface RequestBodyAdapter<C extends Context>
+{
+  /**
+   * Transform a given request body and return the result.
+   *
+   * @param context The context of the request. Provides access to the
+   *                request and corresponding input stream for the body.
+   * @param type The type expected to be returned by this method. This
+   *             corresponds to the declared type of the last argument
+   *             of any handler method using this adapter.
+   * @return The adapted value that was generated from the request's
+   * body. The result is passed to the handler method as the last argument.
+   * @throws RequestBodyException If an unexpected error occurs that cannot
+   * be handled by this method.
+   */
+  Object read(C context, Type type) throws RequestBodyException;
+}

--- a/gemini/src/main/java/com/techempower/gemini/path/RequestBodyException.java
+++ b/gemini/src/main/java/com/techempower/gemini/path/RequestBodyException.java
@@ -1,0 +1,31 @@
+package com.techempower.gemini.path;
+
+/**
+ * An exception that should be thrown by implementations of
+ * {@link RequestBodyAdapter} when something goes wrong. You
+ * must provide an HTTP status code and message that will be
+ * used to generate an error response to the user.
+ */
+public class RequestBodyException extends Exception
+{
+  private final int statusCode;
+
+  public RequestBodyException(int statusCode, String message, Throwable cause)
+  {
+    super(message, cause);
+    this.statusCode = statusCode;
+  }
+
+  public RequestBodyException(int statusCode, String message)
+  {
+    this(statusCode, message, null);
+  }
+
+  /**
+   * The status code to set on the response.
+   */
+  public int getStatusCode()
+  {
+    return statusCode;
+  }
+}

--- a/gemini/src/main/java/com/techempower/gemini/path/StringRequestBodyAdapter.java
+++ b/gemini/src/main/java/com/techempower/gemini/path/StringRequestBodyAdapter.java
@@ -1,0 +1,42 @@
+package com.techempower.gemini.path;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.StringWriter;
+import java.lang.reflect.Type;
+
+import com.techempower.gemini.Context;
+
+/**
+ * Reads the request body into a String.
+ *
+ * @see com.techempower.gemini.path.annotation.ConsumesString
+ */
+public class StringRequestBodyAdapter implements RequestBodyAdapter<Context>
+{
+  private static final int BUFFER_SIZE = 8 * 1024;
+
+  @Override
+  public Object read(Context context, Type type) throws RequestBodyException
+  {
+    try (StringWriter out = new StringWriter())
+    {
+      BufferedReader reader = new BufferedReader(
+              new InputStreamReader(context.getRequest().getInputStream(),
+                      context.getRequest().getRequestCharacterEncoding()));
+      char[] buffer = new char[BUFFER_SIZE];
+      int n;
+      while ((n = reader.read(buffer)) != -1)
+      {
+        out.write(buffer, 0, n);
+      }
+
+      return out.toString();
+    }
+    catch (IOException e)
+    {
+      throw new RequestBodyException(500, "Error reading request body.", e);
+    }
+  }
+}

--- a/gemini/src/main/java/com/techempower/gemini/path/annotation/Body.java
+++ b/gemini/src/main/java/com/techempower/gemini/path/annotation/Body.java
@@ -1,0 +1,58 @@
+package com.techempower.gemini.path.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import com.techempower.gemini.path.RequestBodyAdapter;
+
+/**
+ * <p>An annotation indicating that a handler method expects some
+ * content to be present in the request's body, and that it should
+ * be transformed in some way before being passed to the handler
+ * method.</p>
+ *
+ * <p>You must specify a concrete adapter class that implements
+ * {@link RequestBodyAdapter}. The result of invoking that adapter
+ * is passed as the *last* argument to your handler method. If your
+ * handler method also accepts path parameters, they should be before
+ * the body parameter, otherwise the method should accept just one
+ * argument for the transformed body.</p>
+ *
+ * <p>For example:</p>
+ *
+ * <pre><code>
+ *   &#064;Path("foo/{id}")
+ *   &#064;Put
+ *   &#064;JsonBody // same as &#064;Body(JsonRequestBodyAdapter.class)
+ *   public boolean handleUpdateFoo(long id, Foo foo) {
+ *     // Handler logic...
+ *   }
+ * </code></pre>
+ *
+ * <p>You can also create your own annotations as a shorthand for this
+ * if you wish re-use the same adapter without having to specify it
+ * directly. Simply create an annotation that is annotated with @Body,
+ * then annotate your handler methods with your own annotation.</p>
+ *
+ * <pre><code>
+ *   &#064;Target(ElementType.METHOD)
+ *   &#064;Retention(RetentionPolicy.RUNTIME)
+ *   &#064;Body(MyXmlRequestBodyAdapter.class)
+ *   public @interface XmlBody
+ *   {
+ *   }
+ * </code></pre>
+ *
+ * <p>Intended to be used only with
+ * {@link com.techempower.gemini.path.MethodUriHandler}.</p>
+ *
+ * @see ConsumesJson
+ */
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Body
+{
+  Class<? extends RequestBodyAdapter<?>> value();
+}

--- a/gemini/src/main/java/com/techempower/gemini/path/annotation/Body.java
+++ b/gemini/src/main/java/com/techempower/gemini/path/annotation/Body.java
@@ -54,5 +54,12 @@ import com.techempower.gemini.path.RequestBodyAdapter;
 @Retention(RetentionPolicy.RUNTIME)
 public @interface Body
 {
+  /**
+   * The class used to adapt the request body to the type needed by
+   * the handler method with this annotation. Must be a concrete type
+   * with a public no-arguments constructor.
+   *
+   * @see RequestBodyAdapter
+   */
   Class<? extends RequestBodyAdapter<?>> value();
 }

--- a/gemini/src/main/java/com/techempower/gemini/path/annotation/ConsumesJson.java
+++ b/gemini/src/main/java/com/techempower/gemini/path/annotation/ConsumesJson.java
@@ -1,0 +1,22 @@
+package com.techempower.gemini.path.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import com.techempower.gemini.path.JsonRequestBodyAdapter;
+
+/**
+ * <p>A convenience annotation that is equivalent to
+ * {@code @Body(JsonRequestBodyAdapter.class)}.</p>
+ *
+ * <p>Indicates that the request body should be de-serialized from
+ * JSON and passed as the last parameter to the handler method.</p>
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@Body(JsonRequestBodyAdapter.class)
+public @interface ConsumesJson
+{
+}

--- a/gemini/src/main/java/com/techempower/gemini/path/annotation/ConsumesString.java
+++ b/gemini/src/main/java/com/techempower/gemini/path/annotation/ConsumesString.java
@@ -1,0 +1,23 @@
+package com.techempower.gemini.path.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import com.techempower.gemini.path.StringRequestBodyAdapter;
+
+/**
+ * <p>A convenience annotation that is equivalent to
+ * {@code @Body(StringRequestBodyAdapter.class)}.</p>
+ *
+ * <p>Indicates that the request body should be read into a String
+ * and passed as the last parameter to the handler method. The last
+ * parameter must be a String.</p>
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@Body(StringRequestBodyAdapter.class)
+public @interface ConsumesString
+{
+}

--- a/gemini/src/main/java/com/techempower/gemini/path/annotation/PathSegment.java
+++ b/gemini/src/main/java/com/techempower/gemini/path/annotation/PathSegment.java
@@ -31,7 +31,9 @@ import java.lang.annotation.*;
 /**
  * PathSegment annotation.  Identifies a method within a PathHandler to
  * associate with a specified path segment.  A method annotated as a 
- * PathSegment may accept either zero arguments or one Context argument.
+ * PathSegment may accept either zero arguments, one Context argument,
+ * one body argument (if annotated with {@link Body}), or both (Context
+ * is first and body second, also requires {@link Body}).
  *   <p>
  * By default, the method's name will be used as the URI segment for routing,
  * but a list of alternative URI segments can be provided instead. 

--- a/gemini/src/main/java/com/techempower/gemini/pyxis/handler/SecureMethodSegmentHandler.java
+++ b/gemini/src/main/java/com/techempower/gemini/pyxis/handler/SecureMethodSegmentHandler.java
@@ -28,6 +28,7 @@ package com.techempower.gemini.pyxis.handler;
 
 import java.lang.reflect.*;
 
+import com.esotericsoftware.reflectasm.MethodAccess;
 import com.techempower.gemini.*;
 import com.techempower.gemini.Request.*;
 import com.techempower.gemini.path.*;
@@ -147,15 +148,13 @@ public class SecureMethodSegmentHandler<C extends Context, U extends PyxisUser>
   @Override
   protected PathSegmentMethod analyzeAnnotatedMethod(Method method, HttpMethod httpMethod)
   {
-    final PathSegmentMethod superAnalysis = super.analyzeAnnotatedMethod(method, httpMethod);
     final PathBypassAuth bypassAnnotation = method.getAnnotation(PathBypassAuth.class);
     final boolean authorizationRequired = (bypassAnnotation == null);
 
     return new SecurePathSegmentMethod(
-        superAnalysis.name,
-        superAnalysis.httpMethod,
-        superAnalysis.index, 
-        superAnalysis.contextParameter, 
+        method,
+        httpMethod,
+        this.methodAccess,
         authorizationRequired);
   }
 
@@ -249,10 +248,10 @@ public class SecureMethodSegmentHandler<C extends Context, U extends PyxisUser>
   {
     final boolean authorizationRequired;
     
-    protected SecurePathSegmentMethod(String name, HttpMethod httpMethod, int index, 
-        boolean contextParameter, boolean authorizationRequired)
+    protected SecurePathSegmentMethod(Method method, HttpMethod httpMethod,
+        MethodAccess methodAccess, boolean authorizationRequired)
     {
-      super(name, httpMethod, index, contextParameter);
+      super(method, httpMethod, methodAccess);
       this.authorizationRequired = authorizationRequired;
     }
   }

--- a/gemini/src/main/java/com/techempower/gemini/simulation/SimRequest.java
+++ b/gemini/src/main/java/com/techempower/gemini/simulation/SimRequest.java
@@ -103,7 +103,13 @@ public abstract class SimRequest
       throws UnsupportedEncodingException
   {
   }
-  
+
+  @Override
+  public String getRequestCharacterEncoding()
+  {
+    return null;
+  }
+
   @Override
   public Enumeration<String> getHeaderNames()
   {
@@ -257,6 +263,12 @@ public abstract class SimRequest
 
   @Override
   public HttpMethod getRequestMethod()
+  {
+    return null;
+  }
+
+  @Override
+  public InputStream getInputStream()
   {
     return null;
   }

--- a/gemini/src/main/java/com/techempower/js/JacksonJavaScriptReader.java
+++ b/gemini/src/main/java/com/techempower/js/JacksonJavaScriptReader.java
@@ -1,0 +1,50 @@
+package com.techempower.js;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.Type;
+
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * Uses the Jackson JSON serialization library to read JSON to
+ * Java objects.
+ */
+public class JacksonJavaScriptReader implements JavaScriptReader
+{
+  private final ObjectMapper mapper;
+
+  public JacksonJavaScriptReader()
+  {
+    this.mapper = new ObjectMapper();
+  }
+
+  @Override
+  public <T> T read(String json, Type type)
+  {
+    try
+    {
+      JavaType javaType = mapper.getTypeFactory().constructType(type);
+      return mapper.readValue(json, javaType);
+    }
+    catch (IOException e)
+    {
+      throw new JavaScriptError("Jackson exception.", e);
+    }
+  }
+
+  @Override
+  public <T> T read(InputStream inputStream, Type type)
+  {
+    try
+    {
+      JavaType javaType = mapper.getTypeFactory().constructType(type);
+      return mapper.readValue(inputStream, javaType);
+    }
+    catch (IOException e)
+    {
+      throw new JavaScriptError("Jackson exception.", e);
+    }
+  }
+}

--- a/gemini/src/main/java/com/techempower/js/JavaScriptReader.java
+++ b/gemini/src/main/java/com/techempower/js/JavaScriptReader.java
@@ -1,0 +1,45 @@
+package com.techempower.js;
+
+import java.io.InputStream;
+import java.lang.reflect.Type;
+
+import com.techempower.gemini.GeminiApplication;
+
+/**
+ * Implementations of this interface can read JSON to Java objects. The
+ * standard implementation uses the popular Jackson library.
+ *
+ * @see GeminiApplication#constructJavaScriptReader()
+ */
+public interface JavaScriptReader
+{
+  /**
+   * De-serialize the given json to the given type.
+   *
+   * @param json The raw JSON string to de-serialize. Do not assume that
+   *             this is properly formatted JSON.
+   * @param type The type to de-serialize to. Note that this could be any
+   *             type, including {@link Class}
+   *             or {@link java.lang.reflect.ParameterizedType}.
+   * @param <T>  The type this method is expected to return.
+   * @return The de-serialized object.
+   */
+  <T> T read(String json, Type type);
+
+  /**
+   * De-serialize the given input stream to the given type. If possible
+   * implementations can avoid reading the input stream into a String
+   * before beginning de-serialization, making this more efficient in
+   * cases where an input stream is given that is expected to contain
+   * JSON data.
+   *
+   * @param inputStream The input stream to read JSON from. It's expected to
+   *                    be read until there are no more bytes available.
+   * @param type        The type to de-serialize to. Note that this could be any
+   *                    type, including {@link Class}
+   *                    or {@link java.lang.reflect.ParameterizedType}.
+   * @param <T>  The type this method is expected to return.
+   * @return The de-serialized object.
+   */
+  <T> T read(InputStream inputStream, Type type);
+}


### PR DESCRIPTION
Opening this for initial feedback on the approach.

- Add a new annotation `@Body` indicating that a handler accepts something from the request body
- Add a new interface `RequestBodyAdapter` to be used for transforming the request body into the type needed for the handler method
- Provide convenience default implementations for JSON and Strings, with their own annotations
- Add a JavaScriptReader and default Jackson implementation for the default `JsonRequestBodyAdapter` to use

Example usages:

```java
@Path("foo/{bar}")
@Post
@ConsumesJson
public boolean handleFoo(String bar, MyView body) {
  // handler logic...
}
```

(Using `method.getGenericParameterTypes()` allows the handler method to accept types with generics, for example `Map<String, Object> body`)

The `@Body` annotation can also target other custom annotations for convenience.

```java
@Target(ElementType.METHOD)
@Retention(RetentionPolicy.RUNTIME)
@Body(MyXmlRequestBodyAdapter.class)
public @interface ConsumesXml
{
}

// You can then annotate a handler method with `@ConsumesXml`.
```
