### PR TITLE
Enable STARTTLS

### DIFF
--- a/gemini/src/main/java/com/techempower/gemini/email/EmailServerDescriptor.java
+++ b/gemini/src/main/java/com/techempower/gemini/email/EmailServerDescriptor.java
@@ -157,6 +157,7 @@ public class EmailServerDescriptor
       serverProps.put("mail.smtp.port", "" + smtpPort);
       serverProps.put("mail.smtp.connectiontimeout", "" + timeoutProtoInit);
       serverProps.put("mail.smtp.timeout", "" + timeoutSocket);
+      serverProps.put("mail.smtp.starttls.enable", "true");
       if (authenticator != null)
       {
         serverProps.put("mail.smtp.auth", "true");


### PR DESCRIPTION
This is useful if using the 587 submission port and your server requires
STARTTLS.