### PR TITLE
Stop throwing an exception for a situation that is not an error

### DIFF
--- a/gemini/src/main/java/com/techempower/gemini/cluster/jms/CacheMessageManager.java
+++ b/gemini/src/main/java/com/techempower/gemini/cluster/jms/CacheMessageManager.java
@@ -35,7 +35,7 @@ import com.techempower.gemini.cluster.DistributionListener;
 import com.techempower.gemini.cluster.message.BroadcastMessage;
 import com.techempower.gemini.cluster.message.CacheMessage;
 import com.techempower.gemini.cluster.message.CachedRelationMessage;
-import com.techempower.log.ComponentLog;
+import com.techempower.log.*;
 import com.techempower.util.Configurable;
 import com.techempower.util.EnhancedProperties;
 import com.techempower.util.Identifiable;
@@ -484,8 +484,16 @@ public class CacheMessageManager
                     + ", existing entity: " + entity);
               }
             }
-            else
+            else if (group instanceof EntityGroup)
             {
+              // No problem! Some instance has this as a CacheGroup, thus it is
+              // sent over the message queue. But *this* instance does not have
+              // it as a CacheGroup, only an EntityGroup, which means we have
+              // nothing to update here.
+              log.log("Received 'cache object expired' for an EntityGroup, so not cached. Ignoring:" + cacheMessage,
+                  LogLevel.DEBUG);
+            }
+            else            {
               log.log("Receiving 'cache object expired' but group id is invalid:"
                   + cacheMessage + ", group: " + group);
               application.getNotifier().addNotification(


### PR DESCRIPTION
It is possible for different instances of an application to make different
choices about whether to cache an entity or not. If one instance is caching
it, it correctly sends updates out over the message queue to other
instances. But if a non-caching instance receives such a message, it's not
actually an error. Ignore instead of throwing an exception.