### PR TITLE
Add support for multiple content-type parameters in JSON request body

### DIFF
--- a/gemini/src/main/java/com/techempower/gemini/path/JsonRequestBodyAdapter.java
+++ b/gemini/src/main/java/com/techempower/gemini/path/JsonRequestBodyAdapter.java
@@ -25,8 +25,7 @@ public class JsonRequestBodyAdapter implements RequestBodyAdapter<Context>
     final Request request = context.getRequest();
 
     // Ensure that the requests had the right content type.
-    if (!StringHelper.equalsIgnoreCase(
-            request.getRequestContentType(), GeminiConstants.CONTENT_TYPE_JSON))
+    if (!request.getRequestContentType().contains(GeminiConstants.CONTENT_TYPE_JSON))
     {
       throw new RequestBodyException(400, "Invalid content type: "
           + request.getRequestContentType());


### PR DESCRIPTION
It is pretty common to send additional parameters in the Content-Type, such as 'Content-Type: application/json; charset=UTF-8'. This change adds support for other parameters.

