### PR TITLE
Update pom.xml

### DIFF
--- a/gemini-resin-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/gemini-resin-archetype/src/main/resources/archetype-resources/pom.xml
@@ -22,7 +22,15 @@
       <groupId>com.caucho</groupId>
       <artifactId>resin</artifactId>
       <version>4.0.63</version>
-      <scope>provided</scope>
+      <scope>runtime</scope>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>javax.servlet</groupId>
+      <artifactId>javax.servlet-api</artifactId>
+      <version>3.1.0</version>
+      <scope>runtime</scope>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>com.techempower</groupId>


### PR DESCRIPTION
Changes Resin and servlet-api to be on the classpath at runtime but specifies that they are optional for bundling (war, etc).