### PR TITLE
Fix Failing Build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: java
 
+# https://travis-ci.community/t/error-installing-oraclejdk8-expected-feature-release-number-in-range-of-9-to-14-but-got-8/3766/6
+dist: trusty
+
 hosts:
   - TRAVIS
 

--- a/gemini-resin-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/gemini-resin-archetype/src/main/resources/archetype-resources/pom.xml
@@ -29,7 +29,6 @@
       <groupId>javax.servlet</groupId>
       <artifactId>javax.servlet-api</artifactId>
       <version>3.1.0</version>
-      <scope>runtime</scope>
       <optional>true</optional>
     </dependency>
     <dependency>
@@ -46,11 +45,6 @@
       <groupId>com.techempower</groupId>
       <artifactId>gemini-jdbc</artifactId>
       <version>${geminiVersion}</version>
-    </dependency>
-    <dependency>
-      <groupId>javax.servlet</groupId>
-      <artifactId>javax.servlet-api</artifactId>
-      <version>${servletVersion}</version>
     </dependency>
     <!-- gemini-hikaricp is an alternative to gemini-jdbc -->
     <!-- <dependency> -->

--- a/gemini-resin-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/gemini-resin-archetype/src/main/resources/archetype-resources/pom.xml
@@ -47,6 +47,11 @@
       <artifactId>gemini-jdbc</artifactId>
       <version>${geminiVersion}</version>
     </dependency>
+    <dependency>
+      <groupId>javax.servlet</groupId>
+      <artifactId>javax.servlet-api</artifactId>
+      <version>${servletVersion}</version>
+    </dependency>
     <!-- gemini-hikaricp is an alternative to gemini-jdbc -->
     <!-- <dependency> -->
     <!-- <groupId>com.techempower</groupId> -->

--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,7 @@
     <javassist.version>3.24.1-GA</javassist.version>
     <javax-activation.version>1.1.1</javax-activation.version>
     <javax-mail.version>1.6.2</javax-mail.version>
+    <javax-servlet.version>3.1.0</javax-servlet.version>
     <jbcrypt.version>0.4</jbcrypt.version>
     <jsp.version>2.2.1-b03</jsp.version>
     <junit.version>4.12</junit.version>
@@ -156,6 +157,11 @@
         <groupId>com.sun.mail</groupId>
         <artifactId>javax.mail</artifactId>
         <version>${javax-mail.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>javax.servlet</groupId>
+        <artifactId>javax.servlet-api</artifactId>
+        <version>${javax-servlet.version}</version>
       </dependency>
       <dependency>
         <groupId>org.im4java</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
     <maven-deploy-plugin.version>2.8.2</maven-deploy-plugin.version>
     <maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
     <maven-jar-plugin.version>3.1.1</maven-jar-plugin.version>
-    <maven-war-plugin.version>3.1.1</maven-war-plugin.version>
+    <maven-war-plugin.version>3.1.0</maven-war-plugin.version>
     <maven-javadoc-plugin.version>3.1.0</maven-javadoc-plugin.version>
     <maven-release-plugin.version>2.5.3</maven-release-plugin.version>
     <maven-source-plugin.version>3.0.1</maven-source-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,6 @@
     <javassist.version>3.24.1-GA</javassist.version>
     <javax-activation.version>1.1.1</javax-activation.version>
     <javax-mail.version>1.6.2</javax-mail.version>
-    <javax-servlet.version>3.1.0</javax-servlet.version>
     <jbcrypt.version>0.4</jbcrypt.version>
     <jsp.version>2.2.1-b03</jsp.version>
     <junit.version>4.12</junit.version>
@@ -157,11 +156,6 @@
         <groupId>com.sun.mail</groupId>
         <artifactId>javax.mail</artifactId>
         <version>${javax-mail.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>javax.servlet</groupId>
-        <artifactId>javax.servlet-api</artifactId>
-        <version>${javax-servlet.version}</version>
       </dependency>
       <dependency>
         <groupId>org.im4java</groupId>
@@ -331,6 +325,7 @@
             <archive>
               <manifestEntries>
                 <geminiVersion>${project.version}</geminiVersion>
+                <servletVersion>${servlet.version}</servletVersion>
               </manifestEntries>
               <manifest>
                 <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
@@ -347,6 +342,7 @@
             <archive>
               <manifestEntries>
                 <geminiVersion>${project.version}</geminiVersion>
+                <servletVersion>${servlet.version}</servletVersion>
               </manifestEntries>
               <manifest>
                 <addDefaultImplementationEntries>true</addDefaultImplementationEntries>

--- a/pom.xml
+++ b/pom.xml
@@ -325,7 +325,6 @@
             <archive>
               <manifestEntries>
                 <geminiVersion>${project.version}</geminiVersion>
-                <servletVersion>${servlet.version}</servletVersion>
               </manifestEntries>
               <manifest>
                 <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
@@ -342,7 +341,6 @@
             <archive>
               <manifestEntries>
                 <geminiVersion>${project.version}</geminiVersion>
-                <servletVersion>${servlet.version}</servletVersion>
               </manifestEntries>
               <manifest>
                 <addDefaultImplementationEntries>true</addDefaultImplementationEntries>


### PR DESCRIPTION
Fixes the failing build in a few unrelated ways:

1. After a quick Google search for 
> Expected feature release number in range of 9 to 14, but got: 8

the Travis CI issue appears to be solved by setting a certain property in the `.travis.yml` file. See [this thread](https://travis-ci.community/t/error-installing-oraclejdk8-expected-feature-release-number-in-range-of-9-to-14-but-got-8/3766/6) for details.

2. Changing the targeted version of the maven war plugin to one that exists. `3.1.0`  is the latest `3.1.x` according to [Maven](https://mvnrepository.com/artifact/org.apache.maven.plugins/maven-war-plugin), `3.1.1` does not exist.

3. Changes the `javax.servlet-api` dependency in the archetype to be required at compile time to address another compilation issue.