### PR TITLE
New Path Segment Types

### DIFF
--- a/gemini/src/main/java/com/techempower/gemini/path/MethodUriHandler.java
+++ b/gemini/src/main/java/com/techempower/gemini/path/MethodUriHandler.java
@@ -405,33 +405,47 @@ public class MethodUriHandler<C extends Context>
             args[argsIndex] = 0;
           }
         }
-        // Enum type
-        else if (method.segments[i].type.isEnum())
+        // String, and technically Object too.
+        else if (method.segments[i].type.isAssignableFrom(String.class))
         {
-          try
-          {
-            args[argsIndex] = Enum.valueOf(
-                (Class<? extends Enum>)method.segments[i].type, 
-                segments().get(i));
-          }
-          catch (IllegalArgumentException iae)
-          {
-            // In the case where the developer has specified that only
-            // enumerated values should be accepted as input, either
-            // one of those values needs to exist in the URI, or this
-            // IllegalArgumentException will be thrown. We will limp
-            // on and pass a null in this case.
-            args[argsIndex] = null;
-          }
+          args[argsIndex] = segments().get(i);
         }
-        else // Object types
+        else
         {
-          // String
-          if (method.segments[i].type.isAssignableFrom(String.class))
+          int indexOfMethodToInvoke;
+          Class<?> type = method.segments[i].type;
+          MethodAccess methodAccess = method.segments[i].methodAccess;
+          if (hasStringInputMethod(type, methodAccess, "fromString"))
           {
-            args[argsIndex] = segments().get(i);
+            indexOfMethodToInvoke = methodAccess
+                .getIndex("fromString", String.class);
           }
-          // Default
+          else if (hasStringInputMethod(type, methodAccess, "valueOf"))
+          {
+            indexOfMethodToInvoke = methodAccess
+                .getIndex("valueOf", String.class);
+          }
+          else
+          {
+            indexOfMethodToInvoke = -1;
+          }
+          if (indexOfMethodToInvoke >= 0)
+          {
+            try
+            {
+              args[argsIndex] = methodAccess.invoke(null,
+                  indexOfMethodToInvoke, segments().get(i));
+            }
+            catch (IllegalArgumentException iae)
+            {
+              // In the case where the developer has specified that only
+              // enumerated values should be accepted as input, either
+              // one of those values needs to exist in the URI, or this
+              // IllegalArgumentException will be thrown. We will limp
+              // on and pass a null in this case.
+              args[argsIndex] = null;
+            }
+          }
           else
           {
             // We don't know the type, so we cannot create it.
@@ -451,6 +465,38 @@ public class MethodUriHandler<C extends Context>
     }
 
     return args;
+  }
+
+  private static boolean hasStringInputMethod(Class<?> type,
+                                              MethodAccess methodAccess,
+                                              String methodName) {
+    String[] methodNames = methodAccess.getMethodNames();
+    Class<?>[][] parameterTypes = methodAccess.getParameterTypes();
+    for (int index = 0; index < methodNames.length; index++)
+    {
+      String foundMethodName = methodNames[index];
+      Class<?>[] params = parameterTypes[index];
+      if (foundMethodName.equals(methodName)
+          && params.length == 1
+          && params[0].equals(String.class))
+      {
+        try
+        {
+          // Only bother with the slowness of normal reflection if
+          // the method passes all the other checks.
+          Method method = type.getMethod(methodName, String.class);
+          if (Modifier.isStatic(method.getModifiers()))
+          {
+            return true;
+          }
+        }
+        catch (NoSuchMethodException e)
+        {
+          // Should not happen
+        }
+      }
+    }
+    return false;
   }
   
   protected static class PathUriTree
@@ -658,6 +704,10 @@ public class MethodUriHandler<C extends Context>
           classes[variableCount] = 
               (Class<?>)method.getGenericParameterTypes()[variableCount];
           segment.type = classes[variableCount];
+          if (!segment.type.isPrimitive())
+          {
+            segment.methodAccess = MethodAccess.get(segment.type);
+          }
           // Bump variableCount
           variableCount ++;
         }
@@ -745,10 +795,11 @@ public class MethodUriHandler<C extends Context>
       public static final String VARIABLE_SUFFIX = "}";
       public static final String EMPTY = "";
       
-      public final boolean  isWildcard;
-      public final boolean  isVariable;
-      public final String   segment;
-      public Class<?>       type;
+      public final boolean      isWildcard;
+      public final boolean      isVariable;
+      public final String       segment;
+      public Class<?>           type;
+      public MethodAccess       methodAccess;
       
       public UriSegment(String segment)
       {


### PR DESCRIPTION
TL;DR: Adds support for custom path segment types in `MethodUriHandler`.

TL: This should allow any class with a static method named either `fromString` or `valueOf` that accepts a single `String` argument to be used as a method param for a path segment in a `PathUriHandler` method. For example, where previously you might have had:

```java
@Get
@Path("{id}")
public boolean getById(String idStr) {
  UUID id = UUID.fromString(idStr);
  // ...
}
```
you can now do
```java
@Get
@Path("{id}")
public boolean getById(UUID id) {
  // ...
}
```
The `fromString` method takes priority over `valueOf`. As a result, custom enum conversion can be achieved by simply defining a `fromString` method (so that it doesn't use the implicitly defined `valueOf` method). This also has the added benefit of supporting the object-versions of all the primitive classes, such as `Integer` with `Integer.valueOf(String)`.

This is a tiny part of the specification of jax-rs. Relevant jax-rs doc: https://docs.oracle.com/javaee/7/api/javax/ws/rs/PathParam.html
In that page:
> Have a static method named valueOf or fromString that accepts a single String argument (see, for example, Integer.valueOf(String)).