### PR TITLE
Support referencing environment variables in hikari.properties

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
     <trove4j.version>3.0.3</trove4j.version>
     <jsonwebtoken.version>0.10.6</jsonwebtoken.version>
     <jms.version>2.0.1</jms.version>
-    <hikaricp.version>3.3.1</hikaricp.version>
+    <hikaricp.version>3.4.2</hikaricp.version>
     <slf4j.version>1.8.0-beta4</slf4j.version>
     <flyway.version>6.0.0</flyway.version>
   </properties>


### PR DESCRIPTION
Using the same macro-replacement tags as Gemini configuration, add support for referencing environment variables in hikari.properties.

Also update to the current version of HikariCP.