### PR TITLE
Add SubsetCacheGroup

### DIFF
--- a/gemini/src/main/java/com/techempower/cache/CacheGroup.java
+++ b/gemini/src/main/java/com/techempower/cache/CacheGroup.java
@@ -89,10 +89,11 @@ public class CacheGroup<T extends Identifiable>
       Comparator<? super T> comparator,
       String where, 
       String[] whereArguments,
-      boolean readOnly)
+      boolean readOnly,
+      boolean distribute)
   {
     super(controller, type, table, id, maker, comparator,
-        where, whereArguments, readOnly);
+        where, whereArguments, readOnly, distribute);
   }
 
   /**
@@ -906,6 +907,12 @@ public class CacheGroup<T extends Identifiable>
     protected Builder(Class<T> type)
     {
       super(type);
+
+      // CacheGroups default to true, since it is assumed that other instances are
+      // also using CacheGroups for this entity and will therefore need to notify
+      // DistributionListeners. However, if only a single instance uses a CacheGroup,
+      // this could be set to false to reduce noise on the message queue.
+      this.distribute = true;
     }
     
     @Override
@@ -925,7 +932,8 @@ public class CacheGroup<T extends Identifiable>
           this.comparator,
           this.where,
           this.whereArguments,
-          this.readOnly);
+          this.readOnly,
+          this.distribute);
     }
 
     @Override
@@ -946,6 +954,13 @@ public class CacheGroup<T extends Identifiable>
     public Builder<T> readOnly()
     {
       super.readOnly();
+      return this;
+    }
+
+    @Override
+    public Builder<T> distribute(boolean distribute)
+    {
+      super.distribute(distribute);
       return this;
     }
 

--- a/gemini/src/main/java/com/techempower/cache/CacheGroup.java
+++ b/gemini/src/main/java/com/techempower/cache/CacheGroup.java
@@ -208,30 +208,6 @@ public class CacheGroup<T extends Identifiable>
     return this.objects.get(id);
   }
 
-  /**
-   * Returns an array of objects specified by the identities provided in
-   * an long array parameter.  This formerly provided a performance advantage
-   * over multiple calls to getObject, but that is no longer the case.  It
-   * remains as a convenience method.
-   *   <p>
-   * The array will contain null in any indexes for which an object was not
-   * found for the associated identity.
-   * 
-   * @param identities an long[] of object identities
-   */
-  public Identifiable[] select(long[] identities)
-  {
-    final Identifiable[] toReturn = new Identifiable[identities.length];
-    initializeIfNecessary();
-
-    for (int i = 0; i < identities.length; i++)
-    {
-      toReturn[i] = this.objects.get(identities[i]);
-    }
-    
-    return toReturn;
-  }
-
   @Override
   public List<T> list()
   {

--- a/gemini/src/main/java/com/techempower/cache/CacheGroup.java
+++ b/gemini/src/main/java/com/techempower/cache/CacheGroup.java
@@ -826,7 +826,7 @@ public class CacheGroup<T extends Identifiable>
   @Override
   public String toString()
   {
-    return "CacheGroup [" + name() + "]";
+    return "CacheGroup [" + name() + "; ro: " + this.readOnly() + "; distribute: " + this.distribute() + "]";
   }
 
   @Override

--- a/gemini/src/main/java/com/techempower/cache/EntityStore.java
+++ b/gemini/src/main/java/com/techempower/cache/EntityStore.java
@@ -524,7 +524,7 @@ public class EntityStore
     methodValueCaches.put(group.type(), 
         new MethodValueCache<>(this, group.type()));
     
-    log.debug("Registered {} with id {}", group, group.getGroupNumber());
+    log.info("Registered {} with id {}", group, group.getGroupNumber());
     return group;
   }
 

--- a/gemini/src/main/java/com/techempower/cache/EntityStore.java
+++ b/gemini/src/main/java/com/techempower/cache/EntityStore.java
@@ -1759,6 +1759,14 @@ public class EntityStore
     return Collections.unmodifiableList(typeAdapters);
   }
 
+  /**
+   * Returns whether this EntityStore has completed initialization.
+   */
+  public boolean isInitialized()
+  {
+    return initialized;
+  }
+
   @Override
   public String toString()
   {

--- a/gemini/src/main/java/com/techempower/cache/EntityStore.java
+++ b/gemini/src/main/java/com/techempower/cache/EntityStore.java
@@ -1021,14 +1021,32 @@ public class EntityStore
     }
 
     // Notify the listeners.
+    notifyListenersCacheObjectExpired(true, type, ids);
+  }
+
+  /**
+   * CacheMessageManager needs this in order to notify listeners about specific
+   * objects expiring.
+   * 
+   * @param notifyDistributionListeners Whether to notify distribution listeners.
+   *                                    CacheMessageManager would pass false to
+   *                                    this.
+   * @param type
+   * @param ids
+   */
+  public void notifyListenersCacheObjectExpired(boolean notifyDistributionListeners, Class<? extends Identifiable> type,
+      long... ids)
+  {
     final CacheListener[] toNotify = listeners;
     for (CacheListener listener : toNotify) {
-      for (long id : ids) {
-        listener.cacheObjectExpired(type, id);
+      if (!(listener instanceof DistributionListener) || notifyDistributionListeners) {
+        for (long id : ids) {
+          listener.cacheObjectExpired(type, id);
+        }
       }
     }
   }
-  
+
   /**
    * Puts a data entity into the database/data-store.  This will also cache
    * the entity if a cache is in use.  If the entity is new and is assigned

--- a/gemini/src/main/java/com/techempower/cache/LruCacheGroup.java
+++ b/gemini/src/main/java/com/techempower/cache/LruCacheGroup.java
@@ -208,7 +208,7 @@ public class LruCacheGroup<T extends Identifiable>
   @Override
   public String toString()
   {
-    return "LruCacheGroup [" + getType().getSimpleName() + "]";
+    return "LruCacheGroup [" + name() + "; ro: " + this.readOnly() + "; distribute: " + this.distribute() + "]";
   }
 
   // 

--- a/gemini/src/main/java/com/techempower/cache/LruCacheGroup.java
+++ b/gemini/src/main/java/com/techempower/cache/LruCacheGroup.java
@@ -61,10 +61,11 @@ public class LruCacheGroup<T extends Identifiable>
       String where, 
       String[] whereArguments, 
       int size,
-      boolean readOnly) 
+      boolean readOnly,
+      boolean distribute) 
   {
     super(controller, type, table, id, maker, comparator, where, 
-        whereArguments, readOnly);
+        whereArguments, readOnly, distribute);
     
     objects = CacheBuilder.newBuilder()
         .maximumSize(size)
@@ -249,7 +250,8 @@ public class LruCacheGroup<T extends Identifiable>
           this.where,
           this.whereArguments,
           this.size,
-          this.readOnly);
+          this.readOnly,
+          this.distribute);
     }
 
     @Override

--- a/gemini/src/main/java/com/techempower/cache/PureMemoryGroup.java
+++ b/gemini/src/main/java/com/techempower/cache/PureMemoryGroup.java
@@ -63,10 +63,11 @@ public class PureMemoryGroup<T extends Identifiable>
       EntityMaker<T> maker, 
       Comparator<? super T> comparator, 
       GroupInitializer<T> initializer,
-      boolean readOnly)
+      boolean readOnly,
+      boolean distribute)
   {
     super(entityStore, type, null, null, maker, comparator, null, null, 
-        readOnly);
+        readOnly, distribute);
     this.initializer = initializer;
   }
   
@@ -205,7 +206,8 @@ public class PureMemoryGroup<T extends Identifiable>
           this.maker,
           this.comparator,
           this.initializer,
-          this.readOnly);
+          this.readOnly,
+          this.distribute);
     }
 
     /**

--- a/gemini/src/main/java/com/techempower/cache/PureMemoryGroup.java
+++ b/gemini/src/main/java/com/techempower/cache/PureMemoryGroup.java
@@ -178,6 +178,12 @@ public class PureMemoryGroup<T extends Identifiable>
     return containsRaw(entity);
   }
 
+  @Override
+  public String toString()
+  {
+    return "PureMemoryGroup [" + name() + "; ro: " + this.readOnly() + "; distribute: " + this.distribute() + "]";
+  }
+
   //
   // Inner classes.
   //

--- a/gemini/src/main/java/com/techempower/cache/SubsetCacheGroup.java
+++ b/gemini/src/main/java/com/techempower/cache/SubsetCacheGroup.java
@@ -40,9 +40,9 @@ public class SubsetCacheGroup<T extends Identifiable> extends CacheGroup<T>
    * in.
    */
   protected SubsetCacheGroup(EntityStore controller, Class<T> type, String table, String id, EntityMaker<T> maker,
-      Comparator<? super T> comparator, String where, String[] whereArguments, boolean readOnly)
+      Comparator<? super T> comparator, String where, String[] whereArguments, boolean readOnly, boolean distribute)
   {
-    super(controller, type, table, id, maker, comparator, where, whereArguments, readOnly);
+    super(controller, type, table, id, maker, comparator, where, whereArguments, readOnly, distribute);
   }
 
   /**
@@ -233,7 +233,7 @@ public class SubsetCacheGroup<T extends Identifiable> extends CacheGroup<T>
         throw new NullPointerException();
       }
       return new SubsetCacheGroup<>(controller, this.type, this.table, this.id, this.maker, this.comparator, this.where,
-          this.whereArguments, this.readOnly);
+          this.whereArguments, this.readOnly, this.distribute);
     }
   }
 }

--- a/gemini/src/main/java/com/techempower/cache/SubsetCacheGroup.java
+++ b/gemini/src/main/java/com/techempower/cache/SubsetCacheGroup.java
@@ -26,6 +26,8 @@ import gnu.trove.map.*;
  * <li>contains() is not overridden as it doesn't exist in EntityGroup. You are
  * testing whether the *cache* contains it.
  * <li>size() uses CacheGroup's implementation, and so returns the cached size.
+ * <li>Outside of initialization, nothing automatically adds entities to the
+ * cache or removes them from the cache. You must manage that yourself.
  * </ul>
  */
 public class SubsetCacheGroup<T extends Identifiable> extends CacheGroup<T>

--- a/gemini/src/main/java/com/techempower/cache/SubsetCacheGroup.java
+++ b/gemini/src/main/java/com/techempower/cache/SubsetCacheGroup.java
@@ -172,6 +172,31 @@ public class SubsetCacheGroup<T extends Identifiable> extends CacheGroup<T>
   }
 
   /**
+   * We override this to ensure that we only ask superclass to remove from cache
+   * objects that are already in there. We want this call to be as inexpensive as
+   * possible in case it is called often.
+   */
+  @Override
+  public boolean removeFromCache(long... ids)
+  {
+    List<Long> toRemove = new ArrayList<>();
+    // Build list of IDs that are cached, and should be removed.
+    for (long id : ids) {
+      if (this.contains(id)) {
+        toRemove.add(id);
+      }
+    }
+
+    // Only call super if we have IDs that need to be removed.
+    if (!toRemove.isEmpty()) {
+      return super.removeFromCache(CollectionHelper.toLongArray(toRemove));
+    } else {
+      // Indicating whether the cache was modified.
+      return false;
+    }
+  }
+
+  /**
    * Use EntityGroup's implementation to include both cached and un-cached.
    */
   @Override

--- a/gemini/src/main/java/com/techempower/cache/SubsetCacheGroup.java
+++ b/gemini/src/main/java/com/techempower/cache/SubsetCacheGroup.java
@@ -1,0 +1,212 @@
+package com.techempower.cache;
+
+import java.sql.*;
+import java.util.*;
+
+import org.slf4j.*;
+
+import com.techempower.data.*;
+import com.techempower.helper.*;
+import com.techempower.util.*;
+
+import gnu.trove.map.*;
+
+/**
+ * A variation on CacheGroup that only caches a subset of records. All the
+ * normal operations work on all records, but it only loads into memory those
+ * records returned by the provided initialization query.
+ * <p>
+ * If no query is provided to setInitializeCacheQuery() then everything is
+ * cached and this behaves like a normal CacheGroup with worse performance.
+ * (This is because it calls various raw* methods in EntityGroup, assuming that
+ * the requested entity exists but isn't part of the cached subset.)
+ * <p>
+ * Notes:
+ * <ul>
+ * <li>contains() is not overridden as it doesn't exist in EntityGroup. You are
+ * testing whether the *cache* contains it.
+ * <li>size() uses CacheGroup's implementation, and so returns the cached size.
+ * </ul>
+ */
+public class SubsetCacheGroup<T extends Identifiable> extends CacheGroup<T>
+{
+  private String queryInitializeCache = null;
+  private final Logger log = LoggerFactory.getLogger(getClass());
+
+  /**
+   * Keep same Constructor/Builder signature as CacheGroup to be simple to swap
+   * in.
+   */
+  protected SubsetCacheGroup(EntityStore controller, Class<T> type, String table, String id, EntityMaker<T> maker,
+      Comparator<? super T> comparator, String where, String[] whereArguments, boolean readOnly)
+  {
+    super(controller, type, table, id, maker, comparator, where, whereArguments, readOnly);
+  }
+
+  /**
+   * Needed so we use our SubsetCacheGroup builder instead of the CacheGroup
+   * builder.
+   */
+  public static <T extends Identifiable> Builder<T> of(Class<T> type)
+  {
+    return new Builder<>(type);
+  }
+
+  /**
+   * Overridden to only pull in the subset of objects intended to be cached.
+   */
+  @Override
+  protected List<T> fetchAllPersistedObjects()
+  {
+    if (StringHelper.isEmptyTrimmed(queryInitializeCache)) {
+      // No special query provided so act like a normal CacheGroup.
+      log.warn(
+          "Initializing {} with all entities because no query provided to initialize cache. Recommend either providing a query to setQueryInitializeCache() or using a normal CacheGroup.",
+          this.getType());
+      return super.fetchAllPersistedObjects();
+    }
+    try {
+      // Use provided query to initialize cache.
+      return query(queryInitializeCache);
+    } catch (SQLException e) {
+      throw new EntityException("Exception during SubsetCacheGroup (list).", e);
+    }
+  }
+
+  /**
+   * Log statistics about how many entities are cached.
+   */
+  @Override
+  protected void customPostInitialization()
+  {
+    log.info("{} initialized. Caching {} out of {} entities.", this.getType(), size(), rawSize());
+    super.customPostInitialization();
+  }
+
+  /**
+   * Query used to initialize in-memory cache.
+   * 
+   * @param queryInitializeCache
+   */
+  public void setQueryInitializeCache(String queryInitializeCache)
+  {
+    this.queryInitializeCache = queryInitializeCache;
+  }
+
+  /**
+   * Try to pull requested ID from the cache, but fetch un-cached if needed.
+   */
+  @Override
+  public T get(long id)
+  {
+    T o = super.get(id);
+    if (o == null) {
+      log.trace("{} map() calling rawGet() because not found in cache: {}", this.getType(), id);
+      return rawGet(id);
+    }
+    return o;
+  }
+
+  /**
+   * Include everything, cached and un-cached.
+   */
+  @Override
+  public List<T> list()
+  {
+    return rawList();
+  }
+
+  /**
+   * Try to pull requested IDs from the cache, but fetch un-cached as needed.
+   */
+  @Override
+  public List<T> list(Collection<Long> ids)
+  {
+    // Get what we already have in our cache.
+    List<T> toReturn = super.list(ids);
+
+    // Find any IDs not cached.
+    Collection<Long> missingIds = new ArrayList<>(ids);
+    for (Identifiable o : toReturn) {
+      missingIds.remove(o.getId());
+    }
+
+    // Fetch missing entities and add it to our list to return.
+    if (!missingIds.isEmpty()) {
+      log.trace("{} map() calling rawList() because not found in cache: {}", this.getType(), missingIds);
+      toReturn.addAll(rawList(missingIds));
+    }
+    return toReturn;
+  }
+
+  /**
+   * Include everything, cached and un-cached.
+   */
+  @Override
+  public TLongObjectMap<T> map()
+  {
+    return rawMap();
+  }
+
+  /**
+   * Try to pull requested IDs from the cache, but fetch un-cached as needed.
+   */
+  @Override
+  public TLongObjectMap<T> map(Collection<Long> ids)
+  {
+    // Get what we already have in our cache.
+    TLongObjectMap<T> toReturn = super.map(ids);
+
+    // Find any IDs not cached.
+    Collection<Long> missingIds = new ArrayList<>(ids);
+    for (Long id : toReturn.keys()) {
+      missingIds.remove(id);
+    }
+
+    // Fetch missing entities and add it to our list to return.
+    if (!missingIds.isEmpty()) {
+      log.trace("{} map() calling rawMap() because not found in cache: {}", this.getType(), missingIds);
+      toReturn.putAll(rawMap(missingIds));
+    }
+    return toReturn;
+  }
+
+  /**
+   * Use EntityGroup's implementation to include both cached and un-cached.
+   */
+  @Override
+  public long lowest()
+  {
+    return rawLowest();
+  }
+
+  /**
+   * Use EntityGroup's implementation to include both cached and un-cached.
+   */
+  @Override
+  public long highest()
+  {
+    return rawHighest();
+  }
+
+  /**
+   * Creates new instances of {@code SubsetCacheGroup}.
+   */
+  public static class Builder<T extends Identifiable> extends CacheGroup.Builder<T>
+  {
+    protected Builder(Class<T> type)
+    {
+      super(type);
+    }
+
+    @Override
+    public SubsetCacheGroup<T> build(EntityStore controller)
+    {
+      if (controller == null) {
+        throw new NullPointerException();
+      }
+      return new SubsetCacheGroup<>(controller, this.type, this.table, this.id, this.maker, this.comparator, this.where,
+          this.whereArguments, this.readOnly);
+    }
+  }
+}

--- a/gemini/src/main/java/com/techempower/cache/SubsetCacheGroup.java
+++ b/gemini/src/main/java/com/techempower/cache/SubsetCacheGroup.java
@@ -216,6 +216,12 @@ public class SubsetCacheGroup<T extends Identifiable> extends CacheGroup<T>
     return rawHighest();
   }
 
+  @Override
+  public String toString()
+  {
+    return "SubsetCacheGroup [" + name() + "; ro: " + this.readOnly() + "; distribute: " + this.distribute() + "]";
+  }
+
   /**
    * Creates new instances of {@code SubsetCacheGroup}.
    */

--- a/gemini/src/main/java/com/techempower/data/EntityGroup.java
+++ b/gemini/src/main/java/com/techempower/data/EntityGroup.java
@@ -388,6 +388,14 @@ public class EntityGroup<T extends Identifiable>
    */
   public T get(long idToGet)
   {
+    return rawGet(idToGet);
+  }
+
+  /**
+   * For use by subclasses. Not intended for use by client code.
+   */
+  protected T rawGet(long idToGet)
+  {
     try (
         ConnectionMonitor monitor = this.cf.getConnectionMonitor();
         PreparedStatement statement = monitor.getConnection().prepareStatement(
@@ -600,6 +608,14 @@ public class EntityGroup<T extends Identifiable>
    */
   public int size()
   {
+    return rawSize();
+  }
+
+  /**
+   * For use by subclasses. Not intended for use by client code.
+   */
+  protected int rawSize()
+  {
     try (
         ConnectionMonitor monitor = this.cf.getConnectionMonitor();
         PreparedStatement statement = monitor.getConnection().prepareStatement(
@@ -629,6 +645,14 @@ public class EntityGroup<T extends Identifiable>
    * applicable).
    */
   public List<T> list()
+  {
+    return rawList();
+  }
+
+  /**
+   * For use by subclasses. Not intended for use by client code.
+   */
+  protected List<T> rawList()
   {
     final List<T> objects = new ArrayList<>();
     try (
@@ -667,6 +691,14 @@ public class EntityGroup<T extends Identifiable>
    */
   public List<T> list(Collection<Long> ids)
   {
+    return rawList(ids);
+  }
+
+  /**
+   * For use by subclasses. Not intended for use by client code.
+   */
+  protected List<T> rawList(Collection<Long> ids)
+  {
     final TLongObjectMap<T> map = map(ids);
     final List<T> list = new ArrayList<>(ids.size());
     for (long idToList : ids)
@@ -685,6 +717,14 @@ public class EntityGroup<T extends Identifiable>
    * mapped by id.
    */
   public TLongObjectMap<T> map()
+  {
+    return rawMap();
+  }
+
+  /**
+   * For use by subclasses. Not intended for use by client code.
+   */
+  protected TLongObjectMap<T> rawMap()
   {
     final TLongObjectMap<T> objects = new TLongObjectHashMap<>();
     try (
@@ -719,6 +759,14 @@ public class EntityGroup<T extends Identifiable>
    * Returns a map of objects with the given ids.
    */
   public TLongObjectMap<T> map(Collection<Long> ids)
+  {
+    return rawMap(ids);
+  }
+
+  /**
+   * For use by subclasses. Not intended for use by client code.
+   */
+  protected TLongObjectMap<T> rawMap(Collection<Long> ids)
   {
     if (ids.isEmpty())
     {
@@ -767,6 +815,14 @@ public class EntityGroup<T extends Identifiable>
    */
   public long lowest()
   {
+    return rawLowest();
+  }
+
+  /**
+   * For use by subclasses. Not intended for use by client code.
+   */
+  protected long rawLowest()
+  {
     return identityAggregate("MIN");
   }
 
@@ -775,6 +831,15 @@ public class EntityGroup<T extends Identifiable>
    * result can be computed.
    */
   public long highest()
+  {
+    return rawHighest();
+
+  }
+
+  /**
+   * For use by subclasses. Not intended for use by client code.
+   */
+  protected long rawHighest()
   {
     return identityAggregate("MAX");
   }

--- a/gemini/src/main/java/com/techempower/data/EntityGroup.java
+++ b/gemini/src/main/java/com/techempower/data/EntityGroup.java
@@ -168,6 +168,7 @@ public class EntityGroup<T extends Identifiable>
   private final String getSingleQuery;
   private final String deleteSingleQuery;
   private final boolean readOnly;
+  private final boolean distribute;
   
   private DataFieldToMethodMap[] setMethods = null;
   private DataFieldToMethodMap[] getMethods = null;
@@ -219,7 +220,8 @@ public class EntityGroup<T extends Identifiable>
       Comparator<? super T> comparator,
       String where, 
       String[] whereArguments,
-      boolean readOnly)
+      boolean readOnly,
+      boolean distribute)
   {
     Objects.requireNonNull(entityStore, "EntityStore cannot be null.");
     
@@ -232,6 +234,7 @@ public class EntityGroup<T extends Identifiable>
     this.entityStore = entityStore;
     this.cf = entityStore.getConnectorFactory();
     this.readOnly = readOnly;
+    this.distribute = distribute;
 
     // 
     // Optional fields.
@@ -315,6 +318,14 @@ public class EntityGroup<T extends Identifiable>
   public boolean readOnly()
   {
     return this.readOnly;
+  }
+
+  /**
+   * Returns whether updates should be sent to DistributionListeners.
+   */
+  public boolean distribute()
+  {
+    return this.distribute;
   }
 
   /**
@@ -2195,6 +2206,13 @@ public class EntityGroup<T extends Identifiable>
     protected String where;
     protected String[] whereArguments;
     protected boolean readOnly = false;
+    /**
+     * EntityGroups default to false since if there is nothing cached, there is no
+     * need to notify DistributionListeners. However, if some instances use a
+     * CacheGroup for this entity, then it may be useful to set this to true so
+     * those instances can update their cache.
+     */
+    protected boolean distribute = false;
 
     /**
      * Returns a new builder of {@link EntityGroup} instances.
@@ -2225,7 +2243,8 @@ public class EntityGroup<T extends Identifiable>
           this.comparator,
           this.where,
           this.whereArguments,
-          this.readOnly);
+          this.readOnly,
+          this.distribute);
     }
 
     /**
@@ -2281,6 +2300,16 @@ public class EntityGroup<T extends Identifiable>
     public Builder<T> readOnly()
     {
       this.readOnly = true;
+      return this;
+    }
+
+    /**
+     * Specifies updates to the resulting EntityGroup should be passed to
+     * DistributionListeners.
+     */
+    public Builder<T> distribute(boolean distribute)
+    {
+      this.distribute = distribute;
       return this;
     }
 

--- a/gemini/src/main/java/com/techempower/data/EntityGroup.java
+++ b/gemini/src/main/java/com/techempower/data/EntityGroup.java
@@ -2098,7 +2098,7 @@ public class EntityGroup<T extends Identifiable>
   @Override
   public String toString()
   {
-    return "EntityGroup [" + name() + "]";
+    return "EntityGroup [" + name() + "; ro: " + this.readOnly() + "; distribute: " + this.distribute() + "]";
   }
 
   //

--- a/gemini/src/main/java/com/techempower/gemini/cluster/jms/CacheMessageManager.java
+++ b/gemini/src/main/java/com/techempower/gemini/cluster/jms/CacheMessageManager.java
@@ -187,9 +187,9 @@ public class CacheMessageManager
   public <T extends Identifiable> void cacheTypeReset(Class<T> type)
   {
     final EntityGroup<T> group = this.store.getGroup(type);
-    if (!(group instanceof CacheGroup))
+    if (!group.distribute())
     {
-      return; // Don't distribute notifications for un-cached objects.
+      return; // Don't distribute notifications.
     }
     log.info("Sending 'cache type reset': {}", type.getSimpleName());
 
@@ -204,9 +204,9 @@ public class CacheMessageManager
       long identifier)
   {
     final EntityGroup<T> group = this.store.getGroup(type);
-    if (!(group instanceof CacheGroup))
+    if (!group.distribute())
     {
-      return; // Don't distribute notifications for un-cached objects.
+      return; // Don't distribute notifications.
     }
     log.info("Sending 'cache object expired': {}/{}",
         type.getSimpleName(), identifier);
@@ -233,9 +233,9 @@ public class CacheMessageManager
       long identifier)
   {
     final EntityGroup<T> group = this.store.getGroup(type);
-    if (!(group instanceof CacheGroup))
+    if (!group.distribute())
     {
-      return; // Don't distribute notifications for un-cached objects.
+      return; // Don't distribute notifications.
     }
     log.info("Sending 'remove from cache': {}/{}",
         type.getSimpleName(), identifier);

--- a/gemini/src/main/java/com/techempower/gemini/cluster/jms/CacheMessageManager.java
+++ b/gemini/src/main/java/com/techempower/gemini/cluster/jms/CacheMessageManager.java
@@ -389,6 +389,11 @@ public class CacheMessageManager
     @Override
     public void onMessage(javax.jms.Message message)
     {
+      if (!store.isInitialized())
+      {
+        log.debug("EntityStore is not yet initialized. Ignoring message.");
+        return;
+      }
       BroadcastMessage broadcastMessage = null;
       // cast object to BroadcastMessage
       if (message instanceof ObjectMessage)

--- a/gemini/src/main/java/com/techempower/gemini/cluster/jms/CacheMessageManager.java
+++ b/gemini/src/main/java/com/techempower/gemini/cluster/jms/CacheMessageManager.java
@@ -459,6 +459,7 @@ public class CacheMessageManager
                 // This is a new entity, so create it and put it into the cache.
                 entity = cg.newObjectFromMap(cacheMessage.getObjectProperties());
                 cg.addToCache(entity);
+                store.notifyListenersCacheObjectExpired(false, cg.getType(), entity.getId());
                 log.info("Received 'cache object expired':{}", cacheMessage);
               }
               else
@@ -466,6 +467,7 @@ public class CacheMessageManager
                 // This is an existing entity, so update it.
                 cg.updateObjectFromMap(entity, cacheMessage.getObjectProperties());
                 cg.reorder(entity.getId());
+                store.notifyListenersCacheObjectExpired(false, cg.getType(), entity.getId());
                 log.info(
                     "Received 'cache object expired': {}, existing entity: {}",
                     cacheMessage, entity);


### PR DESCRIPTION
1. Add various raw*() methods to EntityGroup to allow SubsetCacheGroup to
call those implementations directly as needed.
2. Delete CacheGroup.select() because it seems obsolete and not worth
accounting for in SubsetCacheGroup. I'm open to keeping it if desired.