### PR TITLE
Jms improvements

### DIFF
--- a/gemini/src/main/java/com/techempower/gemini/cluster/jms/AsyncConsumer.java
+++ b/gemini/src/main/java/com/techempower/gemini/cluster/jms/AsyncConsumer.java
@@ -27,11 +27,9 @@
 
 package com.techempower.gemini.cluster.jms;
 
-import com.techempower.gemini.GeminiApplication;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import javax.jms.*;
+
+import org.slf4j.*;
 
 /**
  * AsyncConsumer is a thin wrapper for a JMS Consumer with an attached
@@ -57,13 +55,6 @@ public class AsyncConsumer
   {
     this.connection = connection;
     this.destination = destination;
-  }
-
-  @Deprecated(forRemoval = true)
-  public AsyncConsumer(final GeminiApplication application,
-      final Connection connection, final String destination)
-  {
-    this(connection, destination);
   }
 
   /**

--- a/gemini/src/main/java/com/techempower/gemini/cluster/jms/AsyncSubscriber.java
+++ b/gemini/src/main/java/com/techempower/gemini/cluster/jms/AsyncSubscriber.java
@@ -27,11 +27,9 @@
 
 package com.techempower.gemini.cluster.jms;
 
-import com.techempower.gemini.GeminiApplication;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import javax.jms.*;
+
+import org.slf4j.*;
 
 /**
  * AsyncSubscriber is a thin wrapper for a JMS consumer with an attached
@@ -58,13 +56,6 @@ public class AsyncSubscriber
   {
     this.connection = connection;
     this.destination = destination;
-  }
-
-  @Deprecated(forRemoval = true)
-  public AsyncSubscriber(GeminiApplication application,
-      Connection connection, String destination)
-  {
-    this(connection, destination);
   }
 
   /**

--- a/gemini/src/main/java/com/techempower/gemini/cluster/jms/BlockingConsumer.java
+++ b/gemini/src/main/java/com/techempower/gemini/cluster/jms/BlockingConsumer.java
@@ -27,12 +27,9 @@
 
 package com.techempower.gemini.cluster.jms;
 
-import com.techempower.gemini.GeminiApplication;
-import org.slf4j.LoggerFactory;
+import javax.jms.*;
 
-import javax.jms.Connection;
-import javax.jms.JMSException;
-import javax.jms.Session;
+import org.slf4j.*;
 
 /**
  * BlockingConsumer wrapper/helper for a JMS Consumer (for use with
@@ -53,13 +50,6 @@ public class BlockingConsumer
   {
     super(connection, destination);
     this.log = LoggerFactory.getLogger(getClass());
-  }
-
-  @Deprecated(forRemoval = true)
-  public BlockingConsumer(GeminiApplication application,
-      Connection connection, String destination)
-  {
-    this(connection, destination);
   }
 
   /**

--- a/gemini/src/main/java/com/techempower/gemini/cluster/jms/BlockingReceiver.java
+++ b/gemini/src/main/java/com/techempower/gemini/cluster/jms/BlockingReceiver.java
@@ -27,11 +27,9 @@
 
 package com.techempower.gemini.cluster.jms;
 
-import com.techempower.gemini.GeminiApplication;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import javax.jms.*;
+
+import org.slf4j.*;
 
 /**
  * BlockingConsumer wrapper/helper/base-class for a JMS Consumer
@@ -58,13 +56,6 @@ public abstract class BlockingReceiver
   {
     this.connection = connection;
     this.destination = destination;
-  }
-
-  @Deprecated(forRemoval = true)
-  public BlockingReceiver(GeminiApplication application,
-      Connection connection, String destination)
-  {
-    this(connection, destination);
   }
 
   /**

--- a/gemini/src/main/java/com/techempower/gemini/cluster/jms/BlockingSubscriber.java
+++ b/gemini/src/main/java/com/techempower/gemini/cluster/jms/BlockingSubscriber.java
@@ -27,12 +27,9 @@
 
 package com.techempower.gemini.cluster.jms;
 
-import com.techempower.gemini.GeminiApplication;
-import org.slf4j.LoggerFactory;
+import javax.jms.*;
 
-import javax.jms.Connection;
-import javax.jms.JMSException;
-import javax.jms.Session;
+import org.slf4j.*;
 
 /**
  * BlockingSubscriber wrapper/helper for a JMS Consumer (for use with
@@ -53,13 +50,6 @@ public class BlockingSubscriber
   {
     super(connection, destination);
     this.log = LoggerFactory.getLogger(getClass());
-  }
-
-  @Deprecated(forRemoval = true)
-  public BlockingSubscriber(GeminiApplication application,
-      Connection connection, String destination)
-  {
-    this(connection, destination);
   }
 
   /**

--- a/gemini/src/main/java/com/techempower/gemini/cluster/jms/GeminiProducer.java
+++ b/gemini/src/main/java/com/techempower/gemini/cluster/jms/GeminiProducer.java
@@ -27,11 +27,7 @@
 
 package com.techempower.gemini.cluster.jms;
 
-import com.techempower.gemini.GeminiApplication;
-
-import javax.jms.Connection;
-import javax.jms.JMSException;
-import javax.jms.Session;
+import javax.jms.*;
 
 /**
  * JMS Publisher implementation for a publisher-subscriber message queue.
@@ -50,13 +46,6 @@ public class GeminiProducer
   public GeminiProducer(Connection connection, String topic)
   {
     super(connection, topic);
-  }
-
-  @Deprecated(forRemoval = true)
-  public GeminiProducer(GeminiApplication application, Connection connection,
-      String topic)
-  {
-    this(connection, topic);
   }
 
   /**

--- a/gemini/src/main/java/com/techempower/gemini/cluster/jms/GeminiPublisher.java
+++ b/gemini/src/main/java/com/techempower/gemini/cluster/jms/GeminiPublisher.java
@@ -27,11 +27,7 @@
 
 package com.techempower.gemini.cluster.jms;
 
-import com.techempower.gemini.GeminiApplication;
-
-import javax.jms.Connection;
-import javax.jms.JMSException;
-import javax.jms.Session;
+import javax.jms.*;
 
 /**
  * GeminiPublisher implementation for a publisher-subscriber message queue.
@@ -50,13 +46,6 @@ public class GeminiPublisher
   public GeminiPublisher(Connection connection, String topic)
   {
     super(connection, topic);
-  }
-
-  @Deprecated(forRemoval = true)
-  public GeminiPublisher(GeminiApplication application,
-      Connection connection, String topic)
-  {
-    this(connection, topic);
   }
 
   /**

--- a/gemini/src/main/java/com/techempower/gemini/cluster/jms/GeminiPublisher.java
+++ b/gemini/src/main/java/com/techempower/gemini/cluster/jms/GeminiPublisher.java
@@ -35,6 +35,8 @@ import javax.jms.*;
 public class GeminiPublisher
     extends GeminiSender
 {
+  private final int deliveryMode;
+
   /**
    * Constructor. This is of a type <b>AutoCloseable</b>, so this should be
    * used in a <b>try-with</b> construct.
@@ -43,9 +45,10 @@ public class GeminiPublisher
    * a different connection/socket, since different sessions can be built from
    * the same connection object. Connection objects are resource heavy
    */
-  public GeminiPublisher(Connection connection, String topic)
+  public GeminiPublisher(Connection connection, String topic, int deliveryMode)
   {
     super(connection, topic);
+    this.deliveryMode = deliveryMode;
   }
 
   /**
@@ -57,8 +60,9 @@ public class GeminiPublisher
     connection.start();
     session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
     producer = session.createProducer(session.createTopic(destination));
+    producer.setDeliveryMode(deliveryMode);
 
-    log.info("{} publisher@'{}'", connection, destination);
+    log.info("{} publisher@'{}' delivery mode {}", connection, destination, deliveryMode);
     return this;
   }
 

--- a/gemini/src/main/java/com/techempower/gemini/cluster/jms/GeminiSender.java
+++ b/gemini/src/main/java/com/techempower/gemini/cluster/jms/GeminiSender.java
@@ -27,14 +27,14 @@
 
 package com.techempower.gemini.cluster.jms;
 
-import com.techempower.gemini.GeminiApplication;
-import com.techempower.gemini.cluster.message.Message;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import java.util.*;
+import java.util.Map.*;
 
 import javax.jms.*;
-import java.util.Map;
-import java.util.Map.Entry;
+
+import org.slf4j.*;
+
+import com.techempower.gemini.cluster.message.Message;
 
 /**
  * GeminiSender abstract base class for sending Gemini's message type with
@@ -61,13 +61,6 @@ public abstract class GeminiSender
   {
     this.connection = connection;
     this.destination = destination;
-  }
-
-  @Deprecated(forRemoval = true)
-  public GeminiSender(final GeminiApplication application,
-      final Connection connection, final String destination)
-  {
-    this(connection, destination);
   }
 
   /**


### PR DESCRIPTION
1. Allow providing separate ConnectionFactories for publish and subscribe, so the publish one can be a pooled connection.
2. Allow configuring the deliveryMode of the publisher, so an implementation can use NON_PERSISTED if desired.
3. Remove some deprecated constructors.