### PR TITLE
Optionally skip updating methodValueCache/listeners when nothing updated

### DIFF
--- a/gemini/src/main/java/com/techempower/cache/CacheGroup.java
+++ b/gemini/src/main/java/com/techempower/cache/CacheGroup.java
@@ -241,7 +241,7 @@ public class CacheGroup<T extends Identifiable>
    * Add an object to the cache and the data store.
    */
   @Override
-  public void put(T object)
+  public int put(T object)
   {
     if (readOnly())
     {
@@ -255,7 +255,7 @@ public class CacheGroup<T extends Identifiable>
     final boolean persisted = isPersisted(object);
     
     // Persist the object.
-    putPersistent(object);
+    int rowsUpdated = putPersistent(object);
     
     if (persisted)
     {
@@ -268,6 +268,7 @@ public class CacheGroup<T extends Identifiable>
       // Object was not persisted, so let's add it to the cache.
       addToCache(object);
     }
+    return rowsUpdated;
   }
   
   /**
@@ -278,10 +279,10 @@ public class CacheGroup<T extends Identifiable>
    * This method is exposed as a protected class to allow subclasses to 
    * specialize the persistence behavior.  
    */
-  protected void putPersistent(T object)
+  protected int putPersistent(T object)
   {
     // Ask the EntityGroup parent to persist the changes.
-    super.put(object);
+    return super.put(object);
   }
 
   /**
@@ -289,7 +290,7 @@ public class CacheGroup<T extends Identifiable>
    */
   @SuppressWarnings("unchecked")
   @Override
-  public void putAll(Collection<T> objectsToPut)
+  public int putAll(Collection<T> objectsToPut)
   {
     if (readOnly())
     {
@@ -315,7 +316,7 @@ public class CacheGroup<T extends Identifiable>
     }
     
     // Persist the changes.
-    putAllPersistent(objectsToPut);
+    int rowsUpdated = putAllPersistent(objectsToPut);
     
     // Reorder any previously-persisted objects in case the field we are 
     // ordered by was changed.
@@ -323,6 +324,8 @@ public class CacheGroup<T extends Identifiable>
     
     // Add any objects we did not previously know about.
     addToCache(nonPersisted.toArray((T[])Array.newInstance(type(), nonPersisted.size())));
+
+    return rowsUpdated;
   }
   
   /**
@@ -333,10 +336,10 @@ public class CacheGroup<T extends Identifiable>
    * This method is exposed as a protected class to allow subclasses to 
    * specialize the persistence behavior.  
    */
-  protected void putAllPersistent(Collection<T> objectsToPut)
+  protected int putAllPersistent(Collection<T> objectsToPut)
   {
     // Ask the EntityGroup parent to persist the objects.
-    super.putAll(objectsToPut);
+    return super.putAll(objectsToPut);
   }
 
   /**

--- a/gemini/src/main/java/com/techempower/cache/LruCacheGroup.java
+++ b/gemini/src/main/java/com/techempower/cache/LruCacheGroup.java
@@ -144,19 +144,27 @@ public class LruCacheGroup<T extends Identifiable>
   }
   
   @Override
-  public void put(T object)
+  public int put(T object)
   {
-    super.put(object);
+    int rowsUpdated = super.put(object);
     objects.put(object.getId(), object);
+    return rowsUpdated;
   }
   
   @Override
-  public void putAll(Collection<T> objectsToPut)
+  public int putAll(Collection<T> objectsToPut)
   {
+    int rowsUpdated = 0;
     for (T object : objectsToPut) 
     {
-      put(object);
+      int c = put(object);
+      if (c > 0)
+      {
+        // Only accumulate positive values;
+        rowsUpdated += c;
+      }
     }
+    return rowsUpdated;
   }
   
   @Override

--- a/gemini/src/main/java/com/techempower/cache/PureMemoryGroup.java
+++ b/gemini/src/main/java/com/techempower/cache/PureMemoryGroup.java
@@ -111,9 +111,10 @@ public class PureMemoryGroup<T extends Identifiable>
    * of entities.
    */
   @Override
-  protected void putPersistent(T object)
+  protected int putPersistent(T object)
   {
     // Does nothing.
+    return 0;
   }
   
   /**
@@ -121,9 +122,10 @@ public class PureMemoryGroup<T extends Identifiable>
    * of entities.
    */
   @Override
-  protected void putAllPersistent(Collection<T> objects)
+  protected int putAllPersistent(Collection<T> objects)
   {
     // Does nothing.
+    return 0;
   }
 
   /**

--- a/gemini/src/main/java/com/techempower/gemini/cluster/jms/CacheMessageManager.java
+++ b/gemini/src/main/java/com/techempower/gemini/cluster/jms/CacheMessageManager.java
@@ -123,12 +123,12 @@ public class CacheMessageManager
 
     // Create publish connection
     this.publishConnection = publishConnectionFactory.createConnection();
-    instanceID = publishConnection.getClientID();
     publishConnection.start();
+    instanceID = publishConnection.getClientID();
     this.publisher = new GeminiPublisher(publishConnection,
         CacheMessageManager.CACHE_TOPIC_DESTINATION, deliveryMode);
     publisher.start();
-    log.info("JMS publish connection established   @{}", publishConnection.getClientID());
+    log.info("JMS publish connection established   @{}", instanceID);
 
     // Create subscribe connection
     this.subscribeConnection = subscribeConnectionFactory.createConnection();


### PR DESCRIPTION
When useAffectedRows is available, use that to determine whether put()
actually affected rows in the database. If not, don't bother updating the
methodValueCache or notifying the listeners.

This is most valuable as a way to avoid sending pointless JMS messages via
CacheMessageManager.

