### PR TITLE
Better log catastrophic configuration failures on startup

### DIFF
--- a/gemini/src/main/java/com/techempower/gemini/Configurator.java
+++ b/gemini/src/main/java/com/techempower/gemini/Configurator.java
@@ -155,9 +155,9 @@ public class Configurator
         throw new GeminiInitializationError("Unable to read configuration.");
       }
     }
-    catch (Exception exc)
+    catch (Throwable t)
     {
-      throw new GeminiInitializationError("Configuration failed.", exc);
+      throw new GeminiInitializationError("Configuration failed.", t);
     }
   }
 
@@ -494,7 +494,15 @@ public class Configurator
           if (configurable != null)
           {
             log.debug("CW{} configuring {}.", workerId, configurable);
-            configurable.configure(props);
+            try
+            {
+              configurable.configure(props);
+            }
+            catch (Throwable t)
+            {
+              log.error("CW{} configuring {} caught ", workerId, configurable, t);
+              throw t;
+            }
           }
         }
         while (configurable != null);


### PR DESCRIPTION
This helps to ensure if the multi-threaded configuration process experiences a catastrophic failure there is some more helpful logging to investigate the problem.