### PR TITLE
Make CacheMessageManager support the EntityStore method value cache

### DIFF
--- a/gemini/src/main/java/com/techempower/cache/annotation/Indexed.java
+++ b/gemini/src/main/java/com/techempower/cache/annotation/Indexed.java
@@ -29,10 +29,18 @@ package com.techempower.cache.annotation;
 import java.lang.annotation.*;
 
 /**
- * This annotation is used to mark entity classes or methods as indexed.  
- * Classes or methods marked as @Indexed should always cache method values, 
- * even if method value caching is turned off.
+ * This annotation is used to mark entity classes or methods as indexed. Classes
+ * or methods marked as @Indexed should always cache method values, even if
+ * method value caching is turned off.
+ * <p>
+ * <b>IMPORTANT</b>: If you use this annotation in an application that uses the
+ * CacheMessageManager to distribute cache updates to other instances, it is
+ * your responsibility to ensure that your corresponding EntityGroup
+ * ("distribute" defaulting to false) or CacheGroup ("distribute" defaulting to
+ * true) has the "distribute" flag set to true. Otherwise each instance will
+ * risk having a stale method value cache and you'll get wrong answers from
+ * EntityStore.get() and list() and honestly it won't be very fun.
  */
-@Target({ElementType.METHOD, ElementType.TYPE})
+@Target({ ElementType.METHOD, ElementType.TYPE })
 @Retention(RetentionPolicy.RUNTIME)
 public @interface Indexed { }

--- a/gemini/src/main/java/com/techempower/data/EntityGroup.java
+++ b/gemini/src/main/java/com/techempower/data/EntityGroup.java
@@ -2269,6 +2269,13 @@ public class EntityGroup<T extends Identifiable>
      * need to notify DistributionListeners. However, if some instances use a
      * CacheGroup for this entity, then it may be useful to set this to true so
      * those instances can update their cache.
+     * <p>
+     * <b>IMPORTANT</b>: If you use the @Indexed annotation on this entity in an
+     * application that uses the CacheMessageManager to distribute cache updates to
+     * other instances, it is your responsibility to ensure that "distribute" is set
+     * to true. Otherwise each instance will risk having a stale method value cache
+     * and you'll get wrong answers from EntityStore.get() and list() and it
+     * honestly won't be very fun.
      */
     protected boolean distribute = false;
 
@@ -2364,6 +2371,13 @@ public class EntityGroup<T extends Identifiable>
     /**
      * Specifies updates to the resulting EntityGroup should be passed to
      * DistributionListeners.
+     * <p>
+     * <b>IMPORTANT</b>: If you use the @Indexed annotation on this entity in an
+     * application that uses the CacheMessageManager to distribute cache updates to
+     * other instances, it is your responsibility to ensure that "distribute" is set
+     * to true. Otherwise each instance will risk having a stale method value cache
+     * and you'll get wrong answers from EntityStore.get() and list() and it
+     * honestly won't be very fun.
      */
     public Builder<T> distribute(boolean distribute)
     {

--- a/gemini/src/main/java/com/techempower/gemini/cluster/jms/CacheMessageManager.java
+++ b/gemini/src/main/java/com/techempower/gemini/cluster/jms/CacheMessageManager.java
@@ -489,6 +489,9 @@ public class CacheMessageManager
               log.info("Receiving 'cache object expired' but group id is invalid:{}, group: {}",
                   cacheMessage, group);
             }
+            // Now that the object is updated in the cache, update the method value cache if
+            // needed.
+            store.methodValueCacheUpdate(group.getType(), cacheMessage.getObjectId());
 
             break;
           }
@@ -514,6 +517,9 @@ public class CacheMessageManager
                   "invalid: {}, group: {}, cacheMessage: {}",
                   cacheMessage.getGroupId(), group, cacheMessage);
             }
+            // Now that the object is deleted from the cache, also delete from the method
+            // value cache if needed.
+            store.methodValueCacheDelete(group.getType(), cacheMessage.getObjectId());
             break;
           }
           case (CacheMessage.ACTION_GROUP_RESET):


### PR DESCRIPTION
Previously, using the @Indexed annotation on a data entity method would
only work within a single instance. With this change, CacheMessageManager
will update the method value cache as needed.

Note: As commented in several places in this commit, every entity that uses
@Indexed must have its EntityGroup "distribute" attribute set to true for
this to work.