### PR TITLE
Database Migration enhancements

### DIFF
--- a/gemini-resin/src/main/java/com/techempower/gemini/LegacyContext.java
+++ b/gemini-resin/src/main/java/com/techempower/gemini/LegacyContext.java
@@ -709,7 +709,7 @@ public abstract class LegacyContext
   /**
    * Respond with the given text.
    */
-  protected boolean respondWithText(String responseText)
+  public boolean respondWithText(String responseText)
   {
     if (responseText != null)
     {

--- a/gemini-resin/src/main/java/com/techempower/gemini/jsp/NullServletOutputStream.java
+++ b/gemini-resin/src/main/java/com/techempower/gemini/jsp/NullServletOutputStream.java
@@ -222,4 +222,17 @@ public class NullServletOutputStream
     // Does nothing.
   }
 
+  @Override
+  public boolean isReady()
+  {
+    // Always ready to do nothing.
+    return true;
+  }
+
+  @Override
+  public void setWriteListener(WriteListener writeListener)
+  {
+    // Does nothing.
+  }
+
 }   // End NullServletOutputStream.

--- a/gemini-resin/src/main/java/com/techempower/gemini/jsp/RedirectedServletOutputStream.java
+++ b/gemini-resin/src/main/java/com/techempower/gemini/jsp/RedirectedServletOutputStream.java
@@ -255,4 +255,16 @@ public class RedirectedServletOutputStream
     this.destination.flush();
   }
 
+  @Override
+  public boolean isReady()
+  {
+    return true;
+  }
+
+  @Override
+  public void setWriteListener(WriteListener writeListener)
+  {
+    // Do nothing.
+  }
+
 }   // End RedirectedServletOutputStream.

--- a/gemini/src/main/java/com/techempower/gemini/data/DatabaseMigrator.java
+++ b/gemini/src/main/java/com/techempower/gemini/data/DatabaseMigrator.java
@@ -26,6 +26,8 @@
  *******************************************************************************/
 package com.techempower.gemini.data;
 
+import java.util.*;
+
 import javax.sql.*;
 
 import com.techempower.util.*;
@@ -42,4 +44,9 @@ public interface DatabaseMigrator extends Configurable
    * @return The number of successfully applied migrations.
    */
   int migrate(DataSource dataSource);
+
+  /**
+   * Get a list of descriptions of pending migrations. If there are none, returns an empty array.
+   */
+  List<String> listPendingMigrations(DataSource dataSource);
 }

--- a/gemini/src/main/java/com/techempower/gemini/data/FlywayMigrator.java
+++ b/gemini/src/main/java/com/techempower/gemini/data/FlywayMigrator.java
@@ -34,12 +34,12 @@ import javax.sql.*;
 import org.flywaydb.core.*;
 import org.flywaydb.core.api.*;
 import org.flywaydb.core.api.configuration.*;
+import org.flywaydb.core.api.output.*;
+import org.slf4j.*;
 
 import com.techempower.gemini.*;
 import com.techempower.helper.*;
 import com.techempower.util.*;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Implementation of DatabaseMigrator that uses the Flyway library.
@@ -103,9 +103,28 @@ public class FlywayMigrator implements DatabaseMigrator
       {
         log.info("Pending migration: {}", i.getScript());
       }
-      return f.migrate();
+      MigrateResult r = f.migrate();
+      return r.migrationsExecuted;
     }
     log.info("Flyway not initialized. Skipping database migrations.");
     return 0;
+  }
+
+  @Override
+  public List<String> listPendingMigrations(DataSource dataSource)
+  {
+    if (flywayConfig != null)
+    {
+      Flyway f = flywayConfig.dataSource(dataSource).load();
+      MigrationInfo[] pending = f.info().pending();
+      List<String> s = new ArrayList<>(pending.length);
+      for (MigrationInfo i : pending)
+      {
+        s.add(i.getScript());
+      }
+      return s;
+    }
+    log.info("Flyway not initialized. Unable to list pending migrations.");
+    return Collections.emptyList();
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -84,9 +84,9 @@
     <trove4j.version>3.0.3</trove4j.version>
     <jsonwebtoken.version>0.10.6</jsonwebtoken.version>
     <jms.version>2.0.1</jms.version>
-    <hikaricp.version>3.4.2</hikaricp.version>
+    <hikaricp.version>3.4.5</hikaricp.version>
     <slf4j.version>1.8.0-beta4</slf4j.version>
-    <flyway.version>6.0.0</flyway.version>
+    <flyway.version>7.3.1</flyway.version>
     <log4j2.version>2.13.3</log4j2.version>
     <logback.version>1.3.0-alpha2</logback.version>
   </properties>


### PR DESCRIPTION
- applyMigrations: By default true when NOT production. Configurable.
- abortStartupIfPending: By default true. Configurable.
- Update Flyway, HikariCP versions

This gives us the flexibility to automatically apply migrations in some
environments, and not in others. By default, migrations are applied
automatically everywhere EXCEPT production, where it is expected migrations
will be applied manually. Also, instances will refuse to start if there are
pending migrations.