### PR TITLE
Fix cache group race condition

### DIFF
--- a/gemini/src/main/java/com/techempower/data/EntityGroup.java
+++ b/gemini/src/main/java/com/techempower/data/EntityGroup.java
@@ -370,6 +370,17 @@ public class EntityGroup<T extends Identifiable>
   }
 
   /**
+   * Synchronously resets and re-initializes this group of entities.  In
+   * the base class, this doesn't do anything, but subclasses such as
+   * CacheGroup act differently.
+   */
+  public void resetSynchronous()
+  {
+    // Call reset() at least, for subclasses besides CacheGroup.
+    reset();
+  }
+
+  /**
    * Returns the comparator to use when sorting entities of this type.
    */
   public Comparator<? super T> comparator()


### PR DESCRIPTION
Fixes #105. Relatively difficult to demonstrate, but I verified it fixes the issue by replicating it with a local Gemini project, and breakpoints in my IDE set up to pause a thread in `CacheGroup#get` on the right line for 100ms while another thread is resetting the cache for that group. Afterwards I targeted a build of this branch after which I could no longer replicate the issue with the breakpoints in the same places as before.