### PR TITLE
Mysql jdbc driver 8.0.23 compatibility

### DIFF
--- a/gemini/src/main/java/com/techempower/data/EntityGroup.java
+++ b/gemini/src/main/java/com/techempower/data/EntityGroup.java
@@ -453,7 +453,7 @@ public class EntityGroup<T extends Identifiable>
     }
     catch (Exception e)
     {
-      throw new EntityException("Exception during SELECT.", e);
+      throw new EntityException(this.name() + " Exception during SELECT.", e);
     }
     return null;
   }
@@ -608,7 +608,7 @@ public class EntityGroup<T extends Identifiable>
     }
     catch (Exception e)
     {
-      throw new EntityException("Exception during DELETE.", e);
+      throw new EntityException(this.name() + " Exception during DELETE.", e);
     }
   }
 
@@ -647,7 +647,7 @@ public class EntityGroup<T extends Identifiable>
     }
     catch (Exception e)
     {
-      throw new EntityException("Exception during DELETE (removeAll).", e);
+      throw new EntityException(this.name() + " Exception during DELETE (removeAll).", e);
     }
   }
 
@@ -684,7 +684,7 @@ public class EntityGroup<T extends Identifiable>
     }
     catch (Exception e)
     {
-      throw new EntityException("Exception during SELECT (size).", e);
+      throw new EntityException(this.name() + " Exception during SELECT (size).", e);
     }
   }
 
@@ -726,7 +726,7 @@ public class EntityGroup<T extends Identifiable>
     }
     catch (Exception e)
     {
-      throw new EntityException("Exception during SELECT (list).", e);
+      throw new EntityException(this.name() + " Exception during SELECT (list).", e);
     }
     // Skip sorting if not desired.
     if (this.comparator != NO_COMPARATOR)
@@ -802,7 +802,7 @@ public class EntityGroup<T extends Identifiable>
     }
     catch (Exception e)
     {
-      throw new EntityException("Exception during SELECT (map).", e);
+      throw new EntityException(this.name() + " Exception during SELECT (map).", e);
     }
     return objects;
   }
@@ -856,7 +856,7 @@ public class EntityGroup<T extends Identifiable>
     }
     catch (Exception e)
     {
-      throw new EntityException("Exception during SELECT (map).", e);
+      throw new EntityException(this.name() + " Exception during SELECT (map).", e);
     }
     return objects;
   }
@@ -1050,7 +1050,7 @@ public class EntityGroup<T extends Identifiable>
           }
           else
           {
-            throw new EntityException("Identity not returned from INSERT.");
+            throw new EntityException(this.name() + " Identity not returned from INSERT.");
           }
         }
       }
@@ -1058,7 +1058,7 @@ public class EntityGroup<T extends Identifiable>
     }
     catch (SQLException e)
     {
-      throw new EntityException("Exception during INSERT.", e);
+      throw new EntityException(this.name() + " Exception during INSERT.", e);
     }
   }
 
@@ -1187,7 +1187,7 @@ public class EntityGroup<T extends Identifiable>
               }
               if (i != objectsWithoutId.size())
               {
-                throw new EntityException("One or more identities not returned after INSERT.");
+                throw new EntityException(this.name() + " One or more identities not returned after INSERT.");
               }
             }
           }
@@ -1207,7 +1207,7 @@ public class EntityGroup<T extends Identifiable>
     }
     catch (SQLException e)
     {
-      throw new EntityException("Exception during INSERT.", e);
+      throw new EntityException(this.name() + " Exception during INSERT.", e);
     }
   }
 
@@ -1243,7 +1243,7 @@ public class EntityGroup<T extends Identifiable>
     }
     catch (SQLException e)
     {
-      throw new EntityException("Exception during UPDATE.", e);
+      throw new EntityException(this.name() + " Exception during UPDATE.", e);
     }
   }
 
@@ -1287,7 +1287,7 @@ public class EntityGroup<T extends Identifiable>
     }
     catch (SQLException e)
     {
-      throw new EntityException("Exception during UPDATE.", e);
+      throw new EntityException(this.name() + " Exception during UPDATE.", e);
     }
   }
 
@@ -1337,7 +1337,7 @@ public class EntityGroup<T extends Identifiable>
     }
     catch (SQLException e)
     {
-      throw new EntityException("Exception during identity aggregate.", e);
+      throw new EntityException(this.name() + " Exception during identity aggregate.", e);
     }
     return result;  
   }
@@ -1897,7 +1897,7 @@ public class EntityGroup<T extends Identifiable>
     // If neither the table or result set has worked, let's fail.
     if (CollectionHelper.isEmpty(metaData))
     {
-      throw new EntityException("Could not read meta data for table \""
+      throw new EntityException(this.name() + " Could not read meta data for table \""
             + this.table + "\".");
     }
     
@@ -2098,7 +2098,7 @@ public class EntityGroup<T extends Identifiable>
     }
     catch (SQLException e)
     {
-      throw new EntityException("Exception while fetching identity during object initialization.", e);
+      throw new EntityException(this.name() + " Exception while fetching identity during object initialization.", e);
     }
     
     final DataFieldToMethodMap[] mappings = getSetMethodMappingCache(resultSet);
@@ -2118,7 +2118,7 @@ public class EntityGroup<T extends Identifiable>
       }
       catch (Exception e)
       {
-        throw new EntityException("Exception during object initialization (" + map.getMethod().getName() + ").", e);
+        throw new EntityException("Exception during " + this.name() + " object initialization (" + map.getMethod().getName() + ").", e);
       }
     }
     


### PR DESCRIPTION
Make compatible with MySQL JDBC driver 8.0.23

This maintains compatibility with older drivers.

1. When getting the metadata, specify the catalog name. The newer driver returns metadata for all catalogs if this is left null.
2. In deserialize, keep the same behavior if getObject() returns a Date. If it returns a LocalDateTime, handle that appropriately.

Details: https://dev.mysql.com/doc/relnotes/connector-j/8.0/en/news-8-0-23.html