### PR TITLE
Set HTTP status 500 when site is unavailable

### DIFF
--- a/gemini/src/main/java/com/techempower/gemini/GeminiApplication.java
+++ b/gemini/src/main/java/com/techempower/gemini/GeminiApplication.java
@@ -1139,6 +1139,7 @@ public abstract class GeminiApplication
   private void handleError(Context context, String error) throws IOException
   {
     context.setContentType("text/html");
+    context.setStatus(500);
     final Writer writer = context.getWriter();
     writer.write("<html>");
     writer.write("<head><title>Temporarily Unavailable</title>");


### PR DESCRIPTION
When the site is down, it shows an error message but the HTTP code is the
default of 200. This is a problem for load balancers seeing the application
as healthy when it is not.