### PR TITLE
More fully support LRU caching for EntityGroups and EntityRelations.

### DIFF
--- a/gemini/src/main/java/com/techempower/cache/CachedRelation.java
+++ b/gemini/src/main/java/com/techempower/cache/CachedRelation.java
@@ -79,7 +79,7 @@ import org.slf4j.LoggerFactory;
  * @see com.techempower.collection.relation.LongRelation
  */
 public class CachedRelation<L extends Identifiable, R extends Identifiable>
-  implements EntityRelation<L, R>, Identifiable
+  implements EntityRelation<L, R>, CachingEntityRelation<L, R>
 {
   // TODO: Consider whether database-level uniqueness constraints and "INSERT
   // IGNORE" behavior should be supported. This shouldn't matter for
@@ -224,17 +224,7 @@ public class CachedRelation<L extends Identifiable, R extends Identifiable>
     return add(leftID, rightID, true, true, true);
   }
 
-  /**
-   * Adds the specified pair to the relation. 
-   * 
-   * @param leftID the ID of the left value of the pair to be added
-   * @param rightID the ID of the right value of the pair to be added
-   * @param updateDatabase whether to update the database
-   * @param notifyListeners whether to notify the listeners of the change
-   * @param notifyDistributionListeners Whether to notify any
-   * DistributionListeners; only used When notifyListeners is true.
-   * @return <tt>true</tt> if the relation changed as a result of the call
-   */
+  @Override
   public boolean add(long leftID, long rightID, boolean updateDatabase, boolean notifyListeners, boolean notifyDistributionListeners)
   {
     if (!this.loaded)
@@ -319,16 +309,7 @@ public class CachedRelation<L extends Identifiable, R extends Identifiable>
     return addAll(relationToAdd, true, true, true);
   }
 
-  /**
-   * Adds the given pairs to the relation and updates the database.
-   * 
-   * @param relationToAdd the pairs to be added
-   * @param updateDatabase whether to update the database
-   * @param notifyListeners whether to notify the listeners of the change
-   * @param notifyDistributionListeners Whether to notify any
-   * DistributionListeners; only used When notifyListeners is true.
-   * @return <tt>true</tt> if the relation changed as a result of the call
-   */
+  @Override
   public boolean addAll(LongRelation relationToAdd, boolean updateDatabase,
       boolean notifyListeners, boolean notifyDistributionListeners)
   {
@@ -474,11 +455,7 @@ public class CachedRelation<L extends Identifiable, R extends Identifiable>
     }
   }
 
-  /**
-   * Adds the given listener to the relation.
-   * 
-   * @param listener the listener to be added
-   */
+  @Override
   public void addListener(CachedRelationListener listener)
   {
     this.listeners.add(listener);
@@ -490,14 +467,7 @@ public class CachedRelation<L extends Identifiable, R extends Identifiable>
     clear(true, true, true);
   }
 
-  /**
-   * Clears the relation of all pairs.
-   * 
-   * @param updateDatabase whether to update the database
-   * @param notifyListeners whether to notify the listeners of the change
-   * @param notifyDistributionListeners Whether to notify any
-   * DistributionListeners; only used When notifyListeners is true.
-   */
+  @Override
   public void clear(boolean updateDatabase, boolean notifyListeners, boolean notifyDistributionListeners)
   {
     this.lock.writeLock().lock();
@@ -790,11 +760,7 @@ public class CachedRelation<L extends Identifiable, R extends Identifiable>
         : leftValueSet(right.getId());
   }
 
-  /**
-   * Returns a copy of the list of listeners to this relation.
-   * 
-   * @return A copy of the list of listeners to this relation.
-   */
+  @Override
   public List<CachedRelationListener> listeners()
   {
     return new ArrayList<>(this.listeners);
@@ -894,17 +860,7 @@ public class CachedRelation<L extends Identifiable, R extends Identifiable>
     return changed;
   }
 
-  /**
-   * Removes the specified pair of values from this relation.
-   * 
-   * @param leftID the id of the left value of the pair to be removed
-   * @param rightID the id of the right value of the pair to be removed
-   * @param updateDatabase whether to update the database
-   * @param notifyListeners whether to notify the listeners of the change
-   * @param notifyDistributionListeners Whether to notify any
-   * DistributionListeners; only used When notifyListeners is true.
-   * @return <tt>true</tt> if the relation was modified as a result of the call
-   */
+  @Override
   public boolean remove(long leftID, long rightID, boolean updateDatabase, boolean notifyListeners, boolean notifyDistributionListeners)
   {
     if (!this.loaded)
@@ -990,16 +946,7 @@ public class CachedRelation<L extends Identifiable, R extends Identifiable>
     return removeAll(relationToRemove, true, true, true);
   }
 
-  /**
-   * Removes the given pairs from the relation and updates the database.
-   * 
-   * @param relationToRemove the pairs to be removed
-   * @param updateDatabase whether to update the database
-   * @param notifyListeners whether to notify the listeners of the change
-   * @param notifyDistributionListeners Whether to notify any
-   * DistributionListeners; only used When notifyListeners is true.
-   * @return <tt>true</tt> if the relation changed as a result of the call
-   */
+  @Override
   public boolean removeAll(LongRelation relationToRemove, boolean updateDatabase,
       boolean notifyListeners, boolean notifyDistributionListeners)
   {
@@ -1119,7 +1066,7 @@ public class CachedRelation<L extends Identifiable, R extends Identifiable>
           if (!(listener instanceof DistributionListener)
               || notifyDistributionListeners)
           {
-            listener.addAll(this.id, relationToRemove);
+            listener.removeAll(this.id, relationToRemove);
           }
         }
       }
@@ -1151,16 +1098,7 @@ public class CachedRelation<L extends Identifiable, R extends Identifiable>
     return removeLeftValue(leftID, true, true, true);
   }
 
-  /**
-   * Removes the specified left value from this relation.
-   * 
-   * @param leftID the id of the left value to be removed from this relation
-   * @param updateDatabase whether to update the database
-   * @param notifyListeners whether to notify the listeners of the change
-   * @param notifyDistributionListeners Whether to notify any
-   * DistributionListeners; only used When notifyListeners is true.
-   * @return <tt>true</tt> if the relation was modified as a result of the call
-   */
+  @Override
   public boolean removeLeftValue(long leftID, boolean updateDatabase, boolean notifyListeners, boolean notifyDistributionListeners)
   {
     if (!this.loaded)
@@ -1228,17 +1166,7 @@ public class CachedRelation<L extends Identifiable, R extends Identifiable>
     return removeRightValue(rightID, true, true, true);
   }
 
-  /**
-   * Removes the specified right value from this relation.
-   * 
-   * @param rightID the id of the right value to be removed from this 
-   *    relation
-   * @param updateDatabase whether to update the database
-   * @param notifyListeners whether to notify the listeners of the change
-   * @param notifyDistributionListeners Whether to notify any
-   * DistributionListeners; only used When notifyListeners is true.
-   * @return <tt>true</tt> if the relation was modified as a result of the call
-   */
+  @Override
   public boolean removeRightValue(long rightID, boolean updateDatabase, boolean notifyListeners, boolean notifyDistributionListeners)
   {
     if (!this.loaded)
@@ -1313,41 +1241,7 @@ public class CachedRelation<L extends Identifiable, R extends Identifiable>
     return replaceAll(relationToReplace, true, true, true);
   }
 
-  /**
-   * <p>Clears the existing relation, then sets the relation to the passed in
-   * relation.</p>
-   * 
-   * <p>Note that this is generally preferable to doing the following:</p>
-   * 
-   * <pre>
-   * {@code
-   * // foo is a CachedRelation.
-   * foo.clear();
-   * foo.addAll( .. );
-   * }
-   * </pre>
-   * 
-   * <p>The above will cause foo to be empty for a certain window of time.  
-   * Using replaceAll( .. ) will achieve the same end goal of clearing the
-   * current relation and then adding the passed in relation, but will never 
-   * result in a call to this object seeing an empty relation.</p>
-   * 
-   * <p>This call will only block reads very briefly while switching to the
-   * new cached relation and notifying listeners.  If deferDatabaseUpdates is
-   * false, then this blocking extends until the database writes have 
-   * completed.</p>
-   * 
-   * <p>If called with a relation that is equivalent to the current relation, 
-   * this function will immediately return with a value of false and will
-   * not hit the db or notify listeners.</p>
-   * 
-   * @param relationToReplace the pairs to be added
-   * @param updateDatabase whether to update the database
-   * @param notifyListeners whether to notify the listeners of the change
-   * @param notifyDistributionListeners Whether to notify any
-   * DistributionListeners; only used When notifyListeners is true.
-   * @return <tt>true</tt> if the relation changed as a result of the call
-   */
+  @Override
   public boolean replaceAll(LongRelation relationToReplace, boolean updateDatabase,
       boolean notifyListeners, boolean notifyDistributionListeners)
   {
@@ -1484,7 +1378,7 @@ public class CachedRelation<L extends Identifiable, R extends Identifiable>
           if (!(listener instanceof DistributionListener)
               || notifyDistributionListeners)
           {
-            listener.addAll(this.id, relationToReplace);
+            listener.replaceAll(this.id, relationToReplace);
           }
         }
       }
@@ -1519,15 +1413,7 @@ public class CachedRelation<L extends Identifiable, R extends Identifiable>
     reset(true, true);
   }
 
-  /**
-   * Internally marks this relation as "not loaded", which is understood to
-   * mean that it should be reloaded from the database before being used
-   * again.
-   * 
-   * @param notifyListeners whether to notify the listeners of the reset
-   * @param notifyDistributionListeners Whether to notify any
-   * DistributionListeners; only used When notifyListeners is true.
-   */
+  @Override
   public void reset(boolean notifyListeners, boolean notifyDistributionListeners)
   {
     this.lock.writeLock().lock();
@@ -1553,22 +1439,13 @@ public class CachedRelation<L extends Identifiable, R extends Identifiable>
     }
   }
 
-  /**
-   * Resets this relation if it maps objects of the specified type.
-   * 
-   * @param type The type of the cache group being reset.
-   */
+  @Override
   public <T extends Identifiable> void reset(Class<T> type)
   {
     reset(type, true, true);
   }
 
-  /**
-   * Resets this relation if it maps objects of the specified type.
-   * 
-   * @param type The type of the cache group being reset.
-   * @param notifyListeners whether to notify the listeners of the reset
-   */
+  @Override
   public <T extends Identifiable> void reset(Class<T> type, boolean notifyListeners, boolean notifyDistributionListeners)
   {
     if (type.equals(this.leftType)

--- a/gemini/src/main/java/com/techempower/cache/CachingEntityRelation.java
+++ b/gemini/src/main/java/com/techempower/cache/CachingEntityRelation.java
@@ -1,0 +1,198 @@
+package com.techempower.cache;
+
+import java.util.*;
+import com.techempower.collection.relation.*;
+import com.techempower.data.*;
+import com.techempower.util.*;
+
+
+/**
+ * In order for the CacheMessageManager to consistently apply messages to both CachedRelation and
+ * LruSqlEntityRelation we use this interface of common methods. Methods in here were previously in
+ * CachedRelation.
+ *
+ * @param <L> the type of the left values in this relation
+ * @param <R> the type of the right values in this relation
+ */
+public interface CachingEntityRelation<L extends Identifiable, R extends Identifiable>
+    extends EntityRelation<L, R>, Identifiable {
+
+  /**
+   * Adds the given listener to the relation.
+   *
+   * @param listener the listener to be added
+   */
+  default void addListener(CachedRelationListener listener) {
+    // By default ignores messages.
+  }
+
+  /**
+   * Returns a copy of the list of listeners to this relation.
+   *
+   * @return A copy of the list of listeners to this relation.
+   */
+  default List<CachedRelationListener> listeners() {
+    // By default do not maintain a list of listeners.
+    return new ArrayList<CachedRelationListener>(0);
+  }
+
+  /**
+   * Internally marks this relation as "not loaded", which is understood to mean that it should be
+   * reloaded from the database before being used again.
+   *
+   * @param notifyListeners whether to notify the listeners of the reset
+   * @param notifyDistributionListeners Whether to notify any DistributionListeners; only used When
+   *        notifyListeners is true.
+   */
+  void reset(boolean notifyListeners, boolean notifyDistributionListeners);
+
+  /**
+   * Resets this relation if it maps objects of the specified type.
+   *
+   * @param type The type of the cache group being reset.
+   * @param notifyListeners whether to notify the listeners of the reset
+   */
+  <T extends Identifiable> void reset(Class<T> type, boolean notifyListeners,
+      boolean notifyDistributionListeners);
+
+  /**
+   * Resets this relation if it maps objects of the specified type.
+   *
+   * @param type The type of the cache group being reset.
+   */
+  <T extends Identifiable> void reset(Class<T> type);
+
+  /**
+   * Removes the specified pair of values from this relation.
+   * 
+   * @param leftID the id of the left value of the pair to be removed
+   * @param rightID the id of the right value of the pair to be removed
+   * @param updateDatabase whether to update the database
+   * @param notifyListeners whether to notify the listeners of the change
+   * @param notifyDistributionListeners Whether to notify any DistributionListeners; only used When
+   *        notifyListeners is true.
+   * @return <tt>true</tt> if the relation was modified as a result of the call
+   */
+  boolean remove(long leftID, long rightID, boolean updateDatabase, boolean notifyListeners,
+      boolean notifyDistributionListeners);
+
+  /**
+   * Removes the specified right value from this relation.
+   * 
+   * @param rightID the id of the right value to be removed from this relation
+   * @param updateDatabase whether to update the database
+   * @param notifyListeners whether to notify the listeners of the change
+   * @param notifyDistributionListeners Whether to notify any DistributionListeners; only used When
+   *        notifyListeners is true.
+   * @return <tt>true</tt> if the relation was modified as a result of the call
+   */
+  boolean removeRightValue(long rightID, boolean updateDatabase, boolean notifyListeners,
+      boolean notifyDistributionListeners);
+
+  /**
+   * Removes the specified left value from this relation.
+   * 
+   * @param leftID the id of the left value to be removed from this relation
+   * @param updateDatabase whether to update the database
+   * @param notifyListeners whether to notify the listeners of the change
+   * @param notifyDistributionListeners Whether to notify any DistributionListeners; only used When
+   *        notifyListeners is true.
+   * @return <tt>true</tt> if the relation was modified as a result of the call
+   */
+  boolean removeLeftValue(long leftID, boolean updateDatabase, boolean notifyListeners,
+      boolean notifyDistributionListeners);
+
+  /**
+   * <p>
+   * Clears the existing relation, then sets the relation to the passed in relation.
+   * </p>
+   * 
+   * <p>
+   * Note that this is generally preferable to doing the following:
+   * </p>
+   * 
+   * <pre>
+   * {@code
+   * // foo is a CachedRelation.
+   * foo.clear();
+   * foo.addAll( .. );
+   * }
+   * </pre>
+   * 
+   * <p>
+   * The above will cause foo to be empty for a certain window of time. Using replaceAll( .. ) will
+   * achieve the same end goal of clearing the current relation and then adding the passed in
+   * relation, but will never result in a call to this object seeing an empty relation.
+   * </p>
+   * 
+   * <p>
+   * This call will only block reads very briefly while switching to the new cached relation and
+   * notifying listeners. If deferDatabaseUpdates is false, then this blocking extends until the
+   * database writes have completed.
+   * </p>
+   * 
+   * <p>
+   * If called with a relation that is equivalent to the current relation, this function will
+   * immediately return with a value of false and will not hit the db or notify listeners.
+   * </p>
+   * 
+   * @param relationToReplace the pairs to be added
+   * @param updateDatabase whether to update the database
+   * @param notifyListeners whether to notify the listeners of the change
+   * @param notifyDistributionListeners Whether to notify any DistributionListeners; only used When
+   *        notifyListeners is true.
+   * @return <tt>true</tt> if the relation changed as a result of the call
+   */
+  boolean replaceAll(LongRelation relationToReplace, boolean updateDatabase,
+      boolean notifyListeners, boolean notifyDistributionListeners);
+
+  /**
+   * Removes the given pairs from the relation and updates the database.
+   * 
+   * @param relationToRemove the pairs to be removed
+   * @param updateDatabase whether to update the database
+   * @param notifyListeners whether to notify the listeners of the change
+   * @param notifyDistributionListeners Whether to notify any DistributionListeners; only used When
+   *        notifyListeners is true.
+   * @return <tt>true</tt> if the relation changed as a result of the call
+   */
+  boolean removeAll(LongRelation relationToRemove, boolean updateDatabase, boolean notifyListeners,
+      boolean notifyDistributionListeners);
+
+  /**
+   * Clears the relation of all pairs.
+   * 
+   * @param updateDatabase whether to update the database
+   * @param notifyListeners whether to notify the listeners of the change
+   * @param notifyDistributionListeners Whether to notify any DistributionListeners; only used When
+   *        notifyListeners is true.
+   */
+  void clear(boolean updateDatabase, boolean notifyListeners, boolean notifyDistributionListeners);
+
+  /**
+   * Adds the given pairs to the relation and updates the database.
+   * 
+   * @param relationToAdd the pairs to be added
+   * @param updateDatabase whether to update the database
+   * @param notifyListeners whether to notify the listeners of the change
+   * @param notifyDistributionListeners Whether to notify any DistributionListeners; only used When
+   *        notifyListeners is true.
+   * @return <tt>true</tt> if the relation changed as a result of the call
+   */
+  boolean addAll(LongRelation relationToAdd, boolean updateDatabase, boolean notifyListeners,
+      boolean notifyDistributionListeners);
+
+  /**
+   * Adds the specified pair to the relation.
+   * 
+   * @param leftID the ID of the left value of the pair to be added
+   * @param rightID the ID of the right value of the pair to be added
+   * @param updateDatabase whether to update the database
+   * @param notifyListeners whether to notify the listeners of the change
+   * @param notifyDistributionListeners Whether to notify any DistributionListeners; only used When
+   *        notifyListeners is true.
+   * @return <tt>true</tt> if the relation changed as a result of the call
+   */
+  boolean add(long leftID, long rightID, boolean updateDatabase, boolean notifyListeners,
+      boolean notifyDistributionListeners);
+}

--- a/gemini/src/main/java/com/techempower/cache/EntityStore.java
+++ b/gemini/src/main/java/com/techempower/cache/EntityStore.java
@@ -27,30 +27,26 @@
 
 package com.techempower.cache;
 
-import com.google.common.primitives.*;
-import gnu.trove.map.*;
-import gnu.trove.map.hash.*;
-
 import java.lang.reflect.*;
 import java.util.*;
 import java.util.concurrent.*;
-
 import org.reflections.*;
-
+import org.slf4j.*;
+import com.google.common.primitives.*;
 import com.techempower.*;
 import com.techempower.cache.annotation.*;
 import com.techempower.classloader.*;
 import com.techempower.collection.*;
 import com.techempower.data.*;
-import com.techempower.data.EntityGroup.Builder;
+import com.techempower.data.EntityGroup.*;
 import com.techempower.data.annotation.*;
 import com.techempower.gemini.cluster.*;
 import com.techempower.gemini.configuration.*;
 import com.techempower.helper.*;
 import com.techempower.reflect.*;
 import com.techempower.util.*;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import gnu.trove.map.*;
+import gnu.trove.map.hash.*;
 
 /**
  * This class serves as a storage manager for several entity groups and the
@@ -133,7 +129,7 @@ public class EntityStore
    * communicating about cache resets, only affect cached relations, so this
    * list is provided (in addition to the other) as a convenience.
    */
-  private final List<CachedRelation<? extends Identifiable,? extends Identifiable>> cachedRelations = new ArrayList<>();
+  private final List<CachingEntityRelation<? extends Identifiable,? extends Identifiable>> cachedRelations = new ArrayList<>();
 
   /**
    * A map from definition classes (in practice, any arbitrary class) to
@@ -346,7 +342,7 @@ public class EntityStore
     }
 
     // Reset relations.
-    for (CachedRelation<?,?> relation : cachedRelations)
+    for (CachingEntityRelation<?,?> relation : cachedRelations)
     {
       relation.reset(notifyListeners, notifyDistributionListeners);
     }
@@ -389,7 +385,7 @@ public class EntityStore
       boolean notifyListeners, 
       boolean notifyDistributionListeners)
   {
-    for (CachedRelation<?,?> relation : cachedRelations)
+    for (CachingEntityRelation<?,?> relation : cachedRelations)
     {
       relation.reset(type, notifyListeners, notifyListeners);
     }
@@ -515,7 +511,7 @@ public class EntityStore
    * This method is intended for internal use within the Gemini core, not broad
    * use within Gemini applications.
    */
-  public CachedRelation<? extends Identifiable,? extends Identifiable> getCachedRelation(long relationId)
+  public CachingEntityRelation<? extends Identifiable,? extends Identifiable> getCachedRelation(long relationId)
   {
     return cachedRelations.get(Ints.saturatedCast(relationId - 1));
   }
@@ -1228,9 +1224,9 @@ public class EntityStore
   {
     relations.add(relation);
 
-    if (relation instanceof CachedRelation)
+    if (relation instanceof CachingEntityRelation)
     {
-      final CachedRelation<?, ?> cr = (CachedRelation<?, ?>) relation;
+      final CachingEntityRelation<?, ?> cr = (CachingEntityRelation<?, ?>) relation;
       cachedRelations.add(cr);
       // Give the relation a unique ID.
       cr.setId(cachedRelations.size());
@@ -1504,7 +1500,7 @@ public class EntityStore
    * Returns a copy of the list of all cached relations in the cache.  
    * This is a subset of the relations returned by {@link #getRelations()}.
    */
-  public List<CachedRelation<? extends Identifiable, ? extends Identifiable>>
+  public List<CachingEntityRelation<? extends Identifiable, ? extends Identifiable>>
     getCachedRelations()
   {
     return new ArrayList<>(cachedRelations);

--- a/gemini/src/main/java/com/techempower/cache/LruSqlEntityRelation.java
+++ b/gemini/src/main/java/com/techempower/cache/LruSqlEntityRelation.java
@@ -1,0 +1,356 @@
+package com.techempower.cache;
+
+import java.util.*;
+import com.google.common.cache.*;
+import com.techempower.collection.relation.*;
+import com.techempower.data.*;
+import com.techempower.gemini.cluster.*;
+import com.techempower.util.*;
+
+/**
+ * A least-recently-used style caching EntityRelation based on the Guava library's Cache. The guts
+ * are provided by Cache but the usage semantics are similar to CachedRelation.
+ */
+public class LruSqlEntityRelation<L extends Identifiable, R extends Identifiable>
+    extends SqlEntityRelation<L, R> implements CachingEntityRelation<L, R> {
+
+  /**
+   * Creates a new {@link Builder}, which is used to construct a {@link LruSqlEntityRelation}. See
+   * example usage in {@link SqlEntityRelation}.
+   */
+  public static <L extends Identifiable, R extends Identifiable> Builder<L, R> of(Class<L> leftType,
+      Class<R> rightType) {
+    return new LruSqlEntityRelation.Builder<>(leftType, rightType);
+  }
+
+  /**
+   * A unique identifier for this relation to be assigned by the entity store as the relation is
+   * registered.
+   */
+  private long id;
+
+  /**
+   * Our LRU cache supports Many-to-Many.
+   */
+  private final Cache<Long, Set<Long>> leftMap;
+  private final Cache<Long, Set<Long>> rightMap;
+  private final Collection<CachedRelationListener> listeners = new ArrayList<>();
+
+  /**
+   * Constructor.
+   */
+  protected LruSqlEntityRelation(EntityStore store, Class<L> leftType, Class<R> rightType,
+      String tableName, String leftColumn, String rightColumn, int lruCacheSize) {
+    super(store, leftType, rightType, tableName, leftColumn, rightColumn);
+    this.leftMap = CacheBuilder.newBuilder().maximumSize(lruCacheSize).build();
+    this.rightMap = CacheBuilder.newBuilder().maximumSize(lruCacheSize).build();
+  }
+
+  /**
+   * Tries to satisfy first from the LRU cache, only querying the database if required.
+   */
+  @Override
+  public Set<Long> rightIDs(long leftID) {
+    Set<Long> rightSet = leftMap.getIfPresent(leftID);
+    if (rightSet != null) {
+      return rightSet;
+    } else {
+      rightSet = super.rightIDs(leftID);
+      if (!rightSet.isEmpty()) {
+        leftMap.put(leftID, rightSet);
+      }
+      return rightSet;
+    }
+  }
+
+  /**
+   * Tries to satisfy first from the LRU cache, only querying the database if required.
+   */
+  @Override
+  public Set<Long> leftIDs(long rightID) {
+    Set<Long> leftSet = rightMap.getIfPresent(rightID);
+    if (leftSet != null) {
+      return leftSet;
+    } else {
+      leftSet = super.leftIDs(rightID);
+      if (!leftSet.isEmpty()) {
+        rightMap.put(rightID, leftSet);
+      }
+      return leftSet;
+    }
+  }
+
+  @Override
+  public boolean remove(long leftID, long rightID, boolean updateDatabase, boolean notifyListeners,
+      boolean notifyDistributionListeners) {
+    // Invalidate the requested items from our LRU cache. This is potentially invalidating more than
+    // required (in the case of many-to-many relations) but it's not worth the complexity to be
+    // exact about these invalidations.
+    this.leftMap.invalidate(leftID);
+    this.rightMap.invalidate(rightID);
+    boolean toReturn = false; // Not important for this to be strictly accurate.
+    if (updateDatabase) {
+      toReturn = super.remove(leftID, rightID);
+    }
+    if (notifyListeners) {
+      for (CachedRelationListener listener : this.listeners) {
+        if (!(listener instanceof DistributionListener) || notifyDistributionListeners) {
+          listener.remove(this.id, leftID, rightID);
+        }
+      }
+    }
+    return toReturn;
+  }
+
+  @Override
+  public boolean removeLeftValue(long leftID, boolean updateDatabase, boolean notifyListeners,
+      boolean notifyDistributionListeners) {
+    boolean toReturn = false; // Not important for this to be strictly accurate.
+    // Invalidate relevant values in our LRU cache.
+    Set<Long> rightValues = this.leftMap.getIfPresent(leftID);
+    if (rightValues != null && !rightValues.isEmpty()) {
+      for (Long rightId : rightValues) {
+        Set<Long> leftValues = this.rightMap.getIfPresent(rightId);
+        leftValues.remove(leftID);
+        if (leftValues.isEmpty()) {
+          this.rightMap.invalidate(rightId);
+        }
+      }
+      this.leftMap.invalidate(leftID);
+      toReturn = true;
+    }
+    if (updateDatabase) {
+      toReturn = super.removeLeftValue(leftID);
+    }
+    if (notifyListeners) {
+      for (CachedRelationListener listener : this.listeners) {
+        if (!(listener instanceof DistributionListener) || notifyDistributionListeners) {
+          listener.removeLeftValue(this.id, leftID);
+        }
+      }
+    }
+    return toReturn;
+  }
+
+  @Override
+  public boolean removeRightValue(long rightID, boolean updateDatabase, boolean notifyListeners,
+      boolean notifyDistributionListeners) {
+    boolean toReturn = false; // Not important for this to be strictly accurate.
+    // Invalidate relevant values in our LRU cache.
+    Set<Long> leftValues = this.rightMap.getIfPresent(rightID);
+    if (leftValues != null && !leftValues.isEmpty()) {
+      for (Long leftId : leftValues) {
+        Set<Long> rightValues = this.leftMap.getIfPresent(leftId);
+        rightValues.remove(rightID);
+        if (rightValues.isEmpty()) {
+          this.leftMap.invalidate(leftId);
+        }
+      }
+      this.rightMap.invalidate(rightID);
+      toReturn = true;
+    }
+    if (updateDatabase) {
+      toReturn = super.removeRightValue(rightID);
+    }
+    if (notifyListeners) {
+      for (CachedRelationListener listener : this.listeners) {
+        if (!(listener instanceof DistributionListener) || notifyDistributionListeners) {
+          listener.removeRightValue(this.id, rightID);
+        }
+      }
+    }
+    return toReturn;
+  }
+
+  @Override
+  public boolean replaceAll(LongRelation relationToReplace, boolean updateDatabase,
+      boolean notifyListeners, boolean notifyDistributionListeners) {
+    // Invalidate our LRU cache.
+    this.leftMap.invalidateAll();
+    this.rightMap.invalidateAll();
+    boolean toReturn = false; // Not important for this to be strictly accurate.
+    if (updateDatabase) {
+      toReturn = super.replaceAll(relationToReplace);
+    }
+    if (notifyListeners) {
+      for (CachedRelationListener listener : this.listeners) {
+        if (!(listener instanceof DistributionListener) || notifyDistributionListeners) {
+          listener.replaceAll(this.id, relationToReplace);
+        }
+      }
+    }
+    return toReturn;
+  }
+
+  @Override
+  public void reset(boolean notifyListeners, boolean notifyDistributionListeners) {
+    // Invalidate our LRU cache.
+    this.leftMap.invalidateAll();
+    this.rightMap.invalidateAll();
+    if (notifyListeners) {
+      for (CachedRelationListener listener : this.listeners) {
+        if (!(listener instanceof DistributionListener) || notifyDistributionListeners) {
+          listener.reset(this.id);
+        }
+      }
+    }
+  }
+
+  @Override
+  public <T extends Identifiable> void reset(Class<T> type, boolean notifyListeners,
+      boolean notifyDistributionListeners) {
+    reset(notifyListeners, notifyDistributionListeners);
+  }
+
+  @Override
+  public <T extends Identifiable> void reset(Class<T> type) {
+    reset(true, true);
+  }
+
+  @Override
+  public void addListener(CachedRelationListener listener) {
+    this.listeners.add(listener);
+  }
+
+  @Override
+  public List<CachedRelationListener> listeners() {
+    return new ArrayList<>(this.listeners);
+  }
+
+  @Override
+  public long getId() {
+    return id;
+  }
+
+  @Override
+  public void setId(long identity) {
+    this.id = identity;
+  }
+
+  @Override
+  public boolean removeAll(LongRelation relationToRemove, boolean updateDatabase,
+      boolean notifyListeners, boolean notifyDistributionListeners) {
+    // Invalidate our LRU cache.
+    this.leftMap.invalidateAll();
+    this.rightMap.invalidateAll();
+    boolean toReturn = false; // Not important for this to be strictly accurate.
+    if (updateDatabase) {
+      toReturn = super.removeAll(relationToRemove);
+    }
+    if (notifyListeners) {
+      for (CachedRelationListener listener : this.listeners) {
+        if (!(listener instanceof DistributionListener) || notifyDistributionListeners) {
+          listener.removeAll(this.id, relationToRemove);
+        }
+      }
+    }
+    return toReturn;
+  }
+
+  @Override
+  public void clear(boolean updateDatabase, boolean notifyListeners,
+      boolean notifyDistributionListeners) {
+    // Invalidate our LRU cache.
+    this.leftMap.invalidateAll();
+    this.rightMap.invalidateAll();
+    if (updateDatabase) {
+      super.clear();
+    }
+    if (notifyListeners) {
+      for (CachedRelationListener listener : this.listeners) {
+        if (!(listener instanceof DistributionListener) || notifyDistributionListeners) {
+          listener.clear(this.id);
+        }
+      }
+    }
+  }
+
+  @Override
+  public boolean addAll(LongRelation relationToAdd, boolean updateDatabase, boolean notifyListeners,
+      boolean notifyDistributionListeners) {
+    if (relationToAdd == null) {
+      return false;
+    }
+    // Do not update our LRU cache. Wait until a relationship is requested before caching it.
+    boolean toReturn = false; // Not important for this to be strictly accurate.
+    if (updateDatabase) {
+      toReturn = super.addAll(relationToAdd);
+    }
+    if (notifyListeners) {
+      for (CachedRelationListener listener : this.listeners) {
+        if (!(listener instanceof DistributionListener) || notifyDistributionListeners) {
+          listener.addAll(this.id, relationToAdd);
+        }
+      }
+    }
+    return toReturn;
+  }
+
+  @Override
+  public boolean add(long leftID, long rightID, boolean updateDatabase, boolean notifyListeners,
+      boolean notifyDistributionListeners) {
+    // Do not update our LRU cache. Wait until a relationship is requested before caching it.
+    boolean toReturn = false; // Not important for this to be strictly accurate.
+    if (updateDatabase) {
+      toReturn = super.add(leftID, rightID);
+    }
+    if (notifyListeners) {
+      for (CachedRelationListener listener : this.listeners) {
+        if (!(listener instanceof DistributionListener) || notifyDistributionListeners) {
+          listener.add(this.id, leftID, rightID);
+        }
+      }
+    }
+    return toReturn;
+  }
+
+  @Override
+  public String toString()
+  {
+    return "LruSqlEntityRelation ["
+        + leftType().getSimpleName()
+        + "," + rightType().getSimpleName()
+        + "]";
+  }
+
+  /**
+   * Creates new instances of {@link LruSqlEntityRelation}.
+   *
+   * @param <L> the type of the left values in the relation
+   * @param <R> the type of the right values in the relation
+   */
+  public static class Builder<L extends Identifiable, R extends Identifiable>
+      extends SqlEntityRelation.Builder<L, R> {
+    /**
+     * The default size limit is 10,000.
+     */
+    public static final int DEFAULT_SIZE = 10000;
+    protected int lruCacheSize = DEFAULT_SIZE;
+
+    /**
+     * Returns a new builder of {@link LruSqlEntityRelation} instances.
+     *
+     * @param leftType The type of left objects.
+     * @param rightType The type of right objects.
+     */
+    protected Builder(Class<L> leftType, Class<R> rightType) {
+      super(leftType, rightType);
+    }
+
+    @Override
+    public LruSqlEntityRelation<L, R> build(EntityStore store) {
+      Objects.requireNonNull(store);
+      return new LruSqlEntityRelation<>(store, this.leftType, this.rightType, this.table,
+          this.leftColumn, this.rightColumn, this.lruCacheSize);
+    }
+
+    /**
+     * Maximum size of the LRU cache.
+     */
+    public Builder<L, R> lruCacheSize(int size) {
+      this.lruCacheSize = size;
+      return this;
+    }
+  }
+
+}

--- a/gemini/src/main/java/com/techempower/data/SqlEntityRelation.java
+++ b/gemini/src/main/java/com/techempower/data/SqlEntityRelation.java
@@ -572,26 +572,7 @@ public class SqlEntityRelation<L extends Identifiable, R extends Identifiable>
   @Override
   public List<L> leftValueList(long rightID)
   {
-    try (ConnectionMonitor monitor = this.cf.getConnectionMonitor();
-         PreparedStatement selectStatement = monitor.getConnection().prepareStatement(
-             "SELECT " + quotedLeftColumn + " FROM " + quotedTable
-                 + " WHERE " + quotedRightColumn + " = ?;",
-             ResultSet.TYPE_FORWARD_ONLY,
-             ResultSet.CONCUR_READ_ONLY))
-    {
-      selectStatement.setLong(1, rightID);
-      ResultSet resultSet = selectStatement.executeQuery();
-      Set<Long> leftIDs = new HashSet<>();
-      while (resultSet.next())
-      {
-        leftIDs.add(resultSet.getLong(leftColumn));
-      }
-      return store.list(leftType, leftIDs);
-    }
-    catch (SQLException e)
-    {
-      throw new EntityException(e);
-    }
+    return store.list(leftType, leftIDs(rightID));
   }
 
   @Override
@@ -605,26 +586,7 @@ public class SqlEntityRelation<L extends Identifiable, R extends Identifiable>
   @Override
   public Set<L> leftValueSet(long rightID)
   {
-    try (ConnectionMonitor monitor = this.cf.getConnectionMonitor();
-         PreparedStatement selectStatement = monitor.getConnection().prepareStatement(
-             "SELECT " + quotedLeftColumn + " FROM " + quotedTable
-                 + " WHERE " + quotedRightColumn + " = ?;",
-             ResultSet.TYPE_FORWARD_ONLY,
-             ResultSet.CONCUR_READ_ONLY))
-    {
-      selectStatement.setLong(1, rightID);
-      ResultSet resultSet = selectStatement.executeQuery();
-      Set<Long> leftIDs = new HashSet<>();
-      while (resultSet.next())
-      {
-        leftIDs.add(resultSet.getLong(leftColumn));
-      }
-      return new HashSet<>(store.list(leftType, leftIDs));
-    }
-    catch (SQLException e)
-    {
-      throw new EntityException(e);
-    }
+    return new HashSet<>(store.list(leftType, leftIDs(rightID)));
   }
 
   @Override
@@ -1176,26 +1138,7 @@ public class SqlEntityRelation<L extends Identifiable, R extends Identifiable>
   @Override
   public List<R> rightValueList(long leftID)
   {
-    try (ConnectionMonitor monitor = this.cf.getConnectionMonitor();
-         PreparedStatement selectStatement = monitor.getConnection().prepareStatement(
-             "SELECT " + quotedRightColumn + " FROM " + quotedTable
-                 + " WHERE " + quotedLeftColumn + " = ?;",
-             ResultSet.TYPE_FORWARD_ONLY,
-             ResultSet.CONCUR_READ_ONLY))
-    {
-      selectStatement.setLong(1, leftID);
-      ResultSet resultSet = selectStatement.executeQuery();
-      Set<Long> rightIDs = new HashSet<>();
-      while (resultSet.next())
-      {
-        rightIDs.add(resultSet.getLong(rightColumn));
-      }
-      return store.list(rightType, rightIDs);
-    }
-    catch (SQLException e)
-    {
-      throw new EntityException(e);
-    }
+    return store.list(rightType, rightIDs(leftID));
   }
 
   @Override
@@ -1209,26 +1152,7 @@ public class SqlEntityRelation<L extends Identifiable, R extends Identifiable>
   @Override
   public Set<R> rightValueSet(long leftID)
   {
-    try (ConnectionMonitor monitor = this.cf.getConnectionMonitor();
-         PreparedStatement selectStatement = monitor.getConnection().prepareStatement(
-             "SELECT " + quotedRightColumn + " FROM " + quotedTable
-                 + " WHERE " + quotedLeftColumn + " = ?;",
-             ResultSet.TYPE_FORWARD_ONLY,
-             ResultSet.CONCUR_READ_ONLY))
-    {
-      selectStatement.setLong(1, leftID);
-      ResultSet resultSet = selectStatement.executeQuery();
-      Set<Long> rightIDs = new HashSet<>();
-      while (resultSet.next())
-      {
-        rightIDs.add(resultSet.getLong(rightColumn));
-      }
-      return new HashSet<>(store.list(rightType, rightIDs));
-    }
-    catch (SQLException e)
-    {
-      throw new EntityException(e);
-    }
+    return new HashSet<>(store.list(rightType, rightIDs(leftID)));
   }
 
   @Override
@@ -1264,6 +1188,15 @@ public class SqlEntityRelation<L extends Identifiable, R extends Identifiable>
     return this.table;
   }
 
+  @Override
+  public String toString()
+  {
+    return "SqlEntityRelation ["
+        + leftType.getSimpleName()
+        + "," + rightType.getSimpleName()
+        + "]";
+  }
+
   //
   // Inner classes
   //
@@ -1277,11 +1210,11 @@ public class SqlEntityRelation<L extends Identifiable, R extends Identifiable>
   public static class Builder<L extends Identifiable, R extends Identifiable>
       implements EntityRelation.Builder<L, R, SqlEntityRelation<L, R>>
   {
-    private final Class<L> leftType;
-    private final Class<R> rightType;
-    private String table;
-    private String leftColumn;
-    private String rightColumn;
+    protected final Class<L> leftType;
+    protected final Class<R> rightType;
+    protected String table;
+    protected String leftColumn;
+    protected String rightColumn;
 
     /**
      * Returns a new builder of {@link SqlEntityRelation} instances.
@@ -1342,4 +1275,5 @@ public class SqlEntityRelation<L extends Identifiable, R extends Identifiable>
       return this;
     }
   }
+
 }


### PR DESCRIPTION
This provides a middle ground for applications with large relations and entity groups so they don't need to be fully cached (using all that heap space) but can still benefit from LRU caching and otherwise be used similar to when cached and get CacheMessageManager updates appropriately.

Note that for both LruCacheGroup and LruSqlEntityRelation, client code will want to continue to avoid operations that result in reading the full table into memory. These changes enable an application to treat these closer to their fully-cached counterparts, but client code must still beware of the performance consequences of an LruCacheGroup.list() or LruSqlEntityRelation.replaceAll() or removeAll().

- SqlEntityRelation
  - Builder needed its members to be protected so they could be used by the new subclass in LruSqlEntityRelation.
  - leftValueList() and leftValueSet() had the same guts as leftIDs(), so change to simply use leftIDs() instead. Same for rightValueList() and rightValueSet() using rightIDs().
  - Add toString so registered relations are cleanly listed during startup.
- CachingEntityRelation
  - Create new interface to represent functionality shared between CachedRelation and the new LruSqlEntityRelation.
- CachedRelation
  - Implement CachingEntityRelation by changing some existing methods to @Override and moving their comments to the new interface.
  - Fix two bugs in CachedRelation where the wrong listener method was called in removeAll() and replaceAll().
- LruSqlEntityRelation
  - Create new class to provide an LRU cache of relations, similar to what LruCacheGroup does for entities.
- EntityStore
  - Change references of CachedRelation to CachingEntityRelation so LruSqlEntityRelation can be treated the same as CachedRelation.
- LruCacheGroup
  - Add map() for querying by a set of IDs instead of relying on a separate query per desired object.
  - Add querySingle() for querying by arbitrary criteria. Useful for login when User is an LruCacheGroup.
  - Default to distribute=true so LruCacheGroups send/receive cache messages.
- CacheMessageManager
  - Appropriately handle messages for an LruCacheGroup to keep them updated just like a CacheGroup is. This enables easier transitions from CacheGroup to LruCacheGroup.
  - Change references of CachedRelation to CachingEntityRelation so LruSqlEntityRelation can be kept updated just the same as CachedRelation.