### PR TITLE
When invalidating the session make it possible to start using a new one

### DIFF
--- a/gemini/src/main/java/com/techempower/gemini/Context.java
+++ b/gemini/src/main/java/com/techempower/gemini/Context.java
@@ -387,6 +387,20 @@ public abstract class Context
   }
 
   /**
+   * In addition to invalidating the session, also sets the Context.session member variable to null
+   * so it is re-created as needed and is available for immediate use.
+   */
+  public void invalidateSession()
+  {
+    if (this.session != null)
+    {
+      this.session.invalidate();
+    }
+    // Rely on getSession() to create a new session as needed.
+    this.session = null;
+  }
+
+  /**
    * Gets the full standard (non-secure) URL to the Servlet.
    */
   public String getStandardUrl()

--- a/gemini/src/main/java/com/techempower/gemini/context/SessionNamedValues.java
+++ b/gemini/src/main/java/com/techempower/gemini/context/SessionNamedValues.java
@@ -306,11 +306,7 @@ public class SessionNamedValues
    */
   public SessionNamedValues invalidate()
   {
-    final Session session = context.getSession(false);
-    if (session != null)
-    {
-      session.invalidate();
-    }
+    context.invalidateSession();
     return this;
   }
 


### PR DESCRIPTION
Fix an issue where logout would correctly invalidate the session, but the Context.session remained the invalidated one so any subsequent changes to session values during that response would be lost. This change clears Context.session so a new session is created as needed and available for use during this response, instead of needing to wait for a subsequent request for the new session to be available.